### PR TITLE
Refresh reserve in between depositing liquidity and depositing collateral

### DIFF
--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -101,9 +101,10 @@ pub enum LendingInstruction {
     ///   4. `[writable]` Reserve collateral SPL Token mint.
     ///   5. `[]` Lending market account.
     ///   6. `[]` Derived lending market authority.
-    ///   7. `[signer]` User transfer authority ($authority).
-    ///   8. `[]` Clock sysvar.
-    ///   9. `[]` Token program id.
+    ///   7. `[]` Reserve liquidity oracle account.
+    ///   8. `[signer]` User transfer authority ($authority).
+    ///   9. `[]` Clock sysvar.
+    ///   10. `[]` Token program id.
     DepositReserveLiquidity {
         /// Amount of liquidity to deposit in exchange for collateral tokens
         liquidity_amount: u64,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -416,7 +416,20 @@ fn process_refresh_reserve(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     let reserve_info = next_account_info(account_info_iter)?;
     let reserve_liquidity_oracle_info = next_account_info(account_info_iter)?;
     let clock = &Clock::from_account_info(next_account_info(account_info_iter)?)?;
+    _refresh_reserve(
+        program_id,
+        reserve_info,
+        reserve_liquidity_oracle_info,
+        clock,
+    )
+}
 
+fn _refresh_reserve<'a>(
+    program_id: &Pubkey,
+    reserve_info: &AccountInfo<'a>,
+    reserve_liquidity_oracle_info: &AccountInfo<'a>,
+    clock: &Clock,
+) -> ProgramResult {
     let mut reserve = Reserve::unpack(&reserve_info.data.borrow())?;
     if reserve_info.owner != program_id {
         msg!("Reserve provided is not owned by the lending program");
@@ -1000,6 +1013,7 @@ fn process_deposit_reserve_liquidity_and_obligation_collateral(
     let destination_collateral_info = next_account_info(account_info_iter)?;
     let obligation_info = next_account_info(account_info_iter)?;
     let obligation_owner_info = next_account_info(account_info_iter)?;
+    let reserve_liquidity_oracle_info = next_account_info(account_info_iter)?;
     let user_transfer_authority_info = next_account_info(account_info_iter)?;
     let clock = &Clock::from_account_info(next_account_info(account_info_iter)?)?;
     let token_program_id = next_account_info(account_info_iter)?;
@@ -1017,6 +1031,12 @@ fn process_deposit_reserve_liquidity_and_obligation_collateral(
         user_transfer_authority_info,
         clock,
         token_program_id,
+    )?;
+    _refresh_reserve(
+        program_id,
+        reserve_info,
+        reserve_liquidity_oracle_info,
+        clock,
     )?;
     _deposit_obligation_collateral(
         program_id,


### PR DESCRIPTION
The process_deposit_reserve_liquidity_and_obligation_collateral function is broken
because we need to refresh the reserve in the middle. This PR does that.