### PR TITLE
Add validation byte to Obligation account type data

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -140,6 +140,7 @@ fn process_init_lending_market(
         token_program_id: *token_program_id.key,
         oracle_program_id: *oracle_program_id.key,
     });
+
     LendingMarket::pack(lending_market, &mut lending_market_info.data.borrow_mut())?;
 
     Ok(())

--- a/token-lending/program/src/state/mod.rs
+++ b/token-lending/program/src/state/mod.rs
@@ -33,6 +33,22 @@ pub const UNINITIALIZED_VERSION: u8 = 0;
 pub const SLOTS_PER_YEAR: u64 =
     DEFAULT_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT * SECONDS_PER_DAY * 365;
 
+/// Enum for account types
+#[derive(Copy, Clone)]
+#[repr(u8)]
+enum AccountType {
+    Unitialized = 0,
+    Obligation,
+    LendingMarket,
+    Reserve,
+}
+
+impl AccountType {
+    fn to_le_bytes(self) -> [u8; 1] {
+        (self as u8).to_le_bytes()
+    }
+}
+
 // Helpers
 fn pack_decimal(decimal: Decimal, dst: &mut [u8; 16]) {
     *dst = decimal

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -16,7 +16,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(27_000);
+    test.set_bpf_compute_max_units(28_000);
 
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);


### PR DESCRIPTION
Adds a byte to the data payload of the obligation data type to differentiate it between 
different data account types.