### PR TITLE
Add flag on reserve config to disable borrows

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -61,6 +61,8 @@ struct PartialReserveConfig {
     pub fees: PartialReserveFees,
     /// Deposit limit
     pub deposit_limit: Option<u64>,
+    /// Borrow limit
+    pub borrow_limit: Option<u64>,
 }
 
 /// Reserve Fees with optional fields
@@ -491,6 +493,15 @@ fn main() {
                         .required(false)
                         .help("Deposit Limit"),
                 )
+                .arg(
+                    Arg::with_name("borrow_limit")
+                        .long("borrow-limit")
+                        .validator(is_parsable::<u64>)
+                        .value_name("INTEGER")
+                        .takes_value(true)
+                        .required(false)
+                        .help("Borrow Limit"),
+                )
         )
         .get_matches();
 
@@ -565,6 +576,7 @@ fn main() {
             let flash_loan_fee = value_of::<f64>(arg_matches, "flash_loan_fee").unwrap();
             let host_fee_percentage = value_of(arg_matches, "host_fee_percentage").unwrap();
             let deposit_limit = value_of(arg_matches, "deposit_limit").unwrap();
+            let borrow_limit = value_of(arg_matches, "borrow_limit").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -586,6 +598,7 @@ fn main() {
                         host_fee_percentage,
                     },
                     deposit_limit,
+                    borrow_limit,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,
@@ -612,6 +625,7 @@ fn main() {
             let flash_loan_fee = value_of::<f64>(arg_matches, "flash_loan_fee");
             let host_fee_percentage = value_of(arg_matches, "host_fee_percentage");
             let deposit_limit = value_of(arg_matches, "deposit_limit");
+            let borrow_limit = value_of(arg_matches, "borrow_limit");
 
             let borrow_fee_wad = borrow_fee.map(|fee| (fee * WAD as f64) as u64);
             let flash_loan_fee_wad = flash_loan_fee.map(|fee| (fee * WAD as f64) as u64);
@@ -632,6 +646,7 @@ fn main() {
                         host_fee_percentage,
                     },
                     deposit_limit,
+                    borrow_limit,
                 },
                 reserve_pubkey,
                 lending_market_pubkey,
@@ -1020,6 +1035,15 @@ fn command_update_reserve(
             reserve.config.deposit_limit,
         );
         reserve.config.deposit_limit = reserve_config.deposit_limit.unwrap();
+    }
+
+    if reserve_config.borrow_limit.is_some() {
+        println!(
+            "Updating borrow_limit from {} to {}",
+            reserve_config.borrow_limit.unwrap(),
+            reserve.config.borrow_limit,
+        );
+        reserve.config.borrow_limit = reserve_config.borrow_limit.unwrap();
     }
 
     let mut transaction = Transaction::new_with_payer(

--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -409,7 +409,8 @@ impl LendingInstruction {
                 let (borrow_fee_wad, rest) = Self::unpack_u64(rest)?;
                 let (flash_loan_fee_wad, rest) = Self::unpack_u64(rest)?;
                 let (host_fee_percentage, rest) = Self::unpack_u8(rest)?;
-                let (deposit_limit, _) = Self::unpack_u64(rest)?;
+                let (deposit_limit, rest) = Self::unpack_u64(rest)?;
+                let (borrow_limit, _) = Self::unpack_u64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -426,6 +427,7 @@ impl LendingInstruction {
                             host_fee_percentage,
                         },
                         deposit_limit,
+                        borrow_limit,
                     },
                 }
             }
@@ -484,6 +486,7 @@ impl LendingInstruction {
                 let (flash_loan_fee_wad, _rest) = Self::unpack_u64(_rest)?;
                 let (host_fee_percentage, _rest) = Self::unpack_u8(_rest)?;
                 let (deposit_limit, _rest) = Self::unpack_u64(_rest)?;
+                let (borrow_limit, _) = Self::unpack_u64(_rest)?;
 
                 Self::UpdateReserveConfig {
                     config: ReserveConfig {
@@ -500,6 +503,7 @@ impl LendingInstruction {
                             host_fee_percentage,
                         },
                         deposit_limit,
+                        borrow_limit,
                     },
                 }
             }
@@ -596,6 +600,7 @@ impl LendingInstruction {
                                 host_fee_percentage,
                             },
                         deposit_limit,
+                        borrow_limit,
                     },
             } => {
                 buf.push(2);
@@ -611,6 +616,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&flash_loan_fee_wad.to_le_bytes());
                 buf.extend_from_slice(&host_fee_percentage.to_le_bytes());
                 buf.extend_from_slice(&deposit_limit.to_le_bytes());
+                buf.extend_from_slice(&borrow_limit.to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -674,6 +680,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.fees.flash_loan_fee_wad.to_le_bytes());
                 buf.extend_from_slice(&config.fees.host_fee_percentage.to_le_bytes());
                 buf.extend_from_slice(&config.deposit_limit.to_le_bytes());
+                buf.extend_from_slice(&config.borrow_limit.to_le_bytes());
             }
         }
         buf

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1339,6 +1339,14 @@ fn process_borrow_obligation_liquidity(
         msg!("Borrow reserve is stale and must be refreshed in the current slot");
         return Err(LendingError::ReserveStale.into());
     }
+    if Decimal::from(liquidity_amount)
+        .try_add(borrow_reserve.liquidity.borrowed_amount_wads)?
+        .try_floor_u64()?
+        > borrow_reserve.config.borrow_limit
+    {
+        msg!("Cannot borrow above the borrow limit");
+        return Err(LendingError::InvalidAmount.into());
+    }
 
     let mut obligation = Obligation::unpack(&obligation_info.data.borrow())?;
     if obligation_info.owner != program_id {

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -613,6 +613,8 @@ pub struct ReserveConfig {
     pub fees: ReserveFees,
     /// Maximum deposit limit of liquidity in native units, u64::MAX for inf
     pub deposit_limit: u64,
+    /// Borrows disabled
+    pub borrow_limit: u64,
 }
 
 /// Additional fee information on a reserve
@@ -719,7 +721,7 @@ impl IsInitialized for Reserve {
     }
 }
 
-const RESERVE_LEN: usize = 611; // 1 + 8 + 1 + 32 + 32 + 1 + 32 + 32 + 32 + 32 + 8 + 16 + 16 + 16 + 32 + 8 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 8 + 8 + 1 + 8 + 248
+const RESERVE_LEN: usize = 619; // 1 + 8 + 1 + 32 + 32 + 1 + 32 + 32 + 32 + 32 + 8 + 16 + 16 + 16 + 32 + 8 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 8 + 8 + 1 + 8 + 8 + 248
 impl Pack for Reserve {
     const LEN: usize = RESERVE_LEN;
 
@@ -756,6 +758,7 @@ impl Pack for Reserve {
             config_fees_flash_loan_fee_wad,
             config_fees_host_fee_percentage,
             config_deposit_limit,
+            config_borrow_limit,
             _padding,
         ) = mut_array_refs![
             output,
@@ -786,6 +789,7 @@ impl Pack for Reserve {
             8,
             8,
             1,
+            8,
             8,
             248
         ];
@@ -832,6 +836,7 @@ impl Pack for Reserve {
         *config_fees_flash_loan_fee_wad = self.config.fees.flash_loan_fee_wad.to_le_bytes();
         *config_fees_host_fee_percentage = self.config.fees.host_fee_percentage.to_le_bytes();
         *config_deposit_limit = self.config.deposit_limit.to_le_bytes();
+        *config_borrow_limit = self.config.borrow_limit.to_le_bytes();
     }
 
     /// Unpacks a byte buffer into a [ReserveInfo](struct.ReserveInfo.html).
@@ -867,6 +872,7 @@ impl Pack for Reserve {
             config_fees_flash_loan_fee_wad,
             config_fees_host_fee_percentage,
             config_deposit_limit,
+            config_borrow_limit,
             _padding,
         ) = array_refs![
             input,
@@ -897,6 +903,7 @@ impl Pack for Reserve {
             8,
             8,
             1,
+            8,
             8,
             248
         ];
@@ -947,6 +954,7 @@ impl Pack for Reserve {
                     host_fee_percentage: u8::from_le_bytes(*config_fees_host_fee_percentage),
                 },
                 deposit_limit: u64::from_le_bytes(*config_deposit_limit),
+                borrow_limit: u64::from_le_bytes(*config_borrow_limit),
             },
         })
     }

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -48,13 +48,12 @@ pub const TEST_RESERVE_CONFIG: ReserveConfig = ReserveConfig {
     optimal_borrow_rate: 4,
     max_borrow_rate: 30,
     fees: ReserveFees {
-        /// 0.00001% (Aave borrow fee)
         borrow_fee_wad: 100_000_000_000,
-        /// 0.3% (Aave flash loan fee)
         flash_loan_fee_wad: 3_000_000_000_000_000,
         host_fee_percentage: 20,
     },
     deposit_limit: 100_000_000_000,
+    borrow_limit: u64::MAX,
 };
 
 pub const SOL_PYTH_PRODUCT: &str = "3Mnn2fX6rQyUsyELYms1sBJyChWofzSNRoqYzvgMVz5E";

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -313,12 +313,13 @@ async fn test_update_reserve_config() {
         min_borrow_rate: 1,
         optimal_borrow_rate: 5,
         max_borrow_rate: 45,
-        deposit_limit: 1_000_000,
         fees: ReserveFees {
             borrow_fee_wad: 200_000_000_000,
             flash_loan_fee_wad: 5_000_000_000_000_000,
             host_fee_percentage: 15,
         },
+        deposit_limit: 1_000_000,
+        borrow_limit: 300_000,
     };
 
     let mut transaction = Transaction::new_with_payer(


### PR DESCRIPTION
Adds a flag to disable reserve borrows
Also updates the command line tool to be able to change it this