### PR TITLE
Move fee_receiver address to the Reserve Config

### DIFF
--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -410,7 +410,8 @@ impl LendingInstruction {
                 let (flash_loan_fee_wad, rest) = Self::unpack_u64(rest)?;
                 let (host_fee_percentage, rest) = Self::unpack_u8(rest)?;
                 let (deposit_limit, rest) = Self::unpack_u64(rest)?;
-                let (borrow_limit, _) = Self::unpack_u64(rest)?;
+                let (borrow_limit, rest) = Self::unpack_u64(rest)?;
+                let (fee_receiver, _) = Self::unpack_pubkey(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -428,6 +429,7 @@ impl LendingInstruction {
                         },
                         deposit_limit,
                         borrow_limit,
+                        fee_receiver,
                     },
                 }
             }
@@ -486,7 +488,8 @@ impl LendingInstruction {
                 let (flash_loan_fee_wad, _rest) = Self::unpack_u64(_rest)?;
                 let (host_fee_percentage, _rest) = Self::unpack_u8(_rest)?;
                 let (deposit_limit, _rest) = Self::unpack_u64(_rest)?;
-                let (borrow_limit, _) = Self::unpack_u64(_rest)?;
+                let (borrow_limit, _rest) = Self::unpack_u64(_rest)?;
+                let (fee_receiver, _) = Self::unpack_pubkey(_rest)?;
 
                 Self::UpdateReserveConfig {
                     config: ReserveConfig {
@@ -504,6 +507,7 @@ impl LendingInstruction {
                         },
                         deposit_limit,
                         borrow_limit,
+                        fee_receiver,
                     },
                 }
             }
@@ -601,6 +605,7 @@ impl LendingInstruction {
                             },
                         deposit_limit,
                         borrow_limit,
+                        fee_receiver,
                     },
             } => {
                 buf.push(2);
@@ -617,6 +622,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&host_fee_percentage.to_le_bytes());
                 buf.extend_from_slice(&deposit_limit.to_le_bytes());
                 buf.extend_from_slice(&borrow_limit.to_le_bytes());
+                buf.extend_from_slice(&fee_receiver.to_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -681,6 +687,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.fees.host_fee_percentage.to_le_bytes());
                 buf.extend_from_slice(&config.deposit_limit.to_le_bytes());
                 buf.extend_from_slice(&config.borrow_limit.to_le_bytes());
+                buf.extend_from_slice(&config.fee_receiver.to_bytes());
             }
         }
         buf
@@ -739,7 +746,6 @@ pub fn init_reserve(
     reserve_pubkey: Pubkey,
     reserve_liquidity_mint_pubkey: Pubkey,
     reserve_liquidity_supply_pubkey: Pubkey,
-    reserve_liquidity_fee_receiver_pubkey: Pubkey,
     reserve_collateral_mint_pubkey: Pubkey,
     reserve_collateral_supply_pubkey: Pubkey,
     pyth_product_pubkey: Pubkey,
@@ -759,7 +765,7 @@ pub fn init_reserve(
         AccountMeta::new(reserve_pubkey, false),
         AccountMeta::new_readonly(reserve_liquidity_mint_pubkey, false),
         AccountMeta::new(reserve_liquidity_supply_pubkey, false),
-        AccountMeta::new(reserve_liquidity_fee_receiver_pubkey, false),
+        AccountMeta::new(config.fee_receiver, false),
         AccountMeta::new(reserve_collateral_mint_pubkey, false),
         AccountMeta::new(reserve_collateral_supply_pubkey, false),
         AccountMeta::new_readonly(pyth_product_pubkey, false),

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -328,7 +328,6 @@ fn process_init_reserve(
             mint_pubkey: *reserve_liquidity_mint_info.key,
             mint_decimals: reserve_liquidity_mint.decimals,
             supply_pubkey: *reserve_liquidity_supply_info.key,
-            fee_receiver: *reserve_liquidity_fee_receiver_info.key,
             pyth_oracle_pubkey: *pyth_price_info.key,
             switchboard_oracle_pubkey: *switchboard_feed_info.key,
             market_price,
@@ -1331,7 +1330,7 @@ fn process_borrow_obligation_liquidity(
         );
         return Err(LendingError::InvalidAccountInput.into());
     }
-    if &borrow_reserve.liquidity.fee_receiver != borrow_reserve_liquidity_fee_receiver_info.key {
+    if &borrow_reserve.config.fee_receiver != borrow_reserve_liquidity_fee_receiver_info.key {
         msg!("Borrow reserve liquidity fee receiver does not match the borrow reserve liquidity fee receiver provided");
         return Err(LendingError::InvalidAccountInput.into());
     }
@@ -1813,7 +1812,7 @@ fn process_flash_loan(
         msg!("Reserve liquidity supply must be used as the source liquidity provided");
         return Err(LendingError::InvalidAccountInput.into());
     }
-    if &reserve.liquidity.fee_receiver != reserve_liquidity_fee_receiver_info.key {
+    if &reserve.config.fee_receiver != reserve_liquidity_fee_receiver_info.key {
         msg!("Reserve liquidity fee receiver does not match the reserve liquidity fee receiver provided");
         return Err(LendingError::InvalidAccountInput.into());
     }

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -353,8 +353,6 @@ pub struct ReserveLiquidity {
     pub mint_decimals: u8,
     /// Reserve liquidity supply address
     pub supply_pubkey: Pubkey,
-    /// Reserve liquidity fee receiver address
-    pub fee_receiver: Pubkey,
     /// Reserve liquidity pyth oracle account
     pub pyth_oracle_pubkey: Pubkey,
     /// Reserve liquidity switchboard oracle account
@@ -376,7 +374,6 @@ impl ReserveLiquidity {
             mint_pubkey: params.mint_pubkey,
             mint_decimals: params.mint_decimals,
             supply_pubkey: params.supply_pubkey,
-            fee_receiver: params.fee_receiver,
             pyth_oracle_pubkey: params.pyth_oracle_pubkey,
             switchboard_oracle_pubkey: params.switchboard_oracle_pubkey,
             available_amount: 0,
@@ -478,8 +475,6 @@ pub struct NewReserveLiquidityParams {
     pub mint_decimals: u8,
     /// Reserve liquidity supply address
     pub supply_pubkey: Pubkey,
-    /// Reserve liquidity fee receiver address
-    pub fee_receiver: Pubkey,
     /// Reserve liquidity pyth oracle account
     pub pyth_oracle_pubkey: Pubkey,
     /// Reserve liquidity switchboard oracle account
@@ -615,6 +610,8 @@ pub struct ReserveConfig {
     pub deposit_limit: u64,
     /// Borrows disabled
     pub borrow_limit: u64,
+    /// Reserve liquidity fee receiver address
+    pub fee_receiver: Pubkey,
 }
 
 /// Additional fee information on a reserve
@@ -721,7 +718,7 @@ impl IsInitialized for Reserve {
     }
 }
 
-const RESERVE_LEN: usize = 619; // 1 + 8 + 1 + 32 + 32 + 1 + 32 + 32 + 32 + 32 + 8 + 16 + 16 + 16 + 32 + 8 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 8 + 8 + 1 + 8 + 8 + 248
+const RESERVE_LEN: usize = 619; // 1 + 8 + 1 + 32 + 32 + 1 + 32 + 32 + 32 + 8 + 16 + 16 + 16 + 32 + 8 + 32 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 8 + 8 + 1 + 8 + 8 + 32 + 248
 impl Pack for Reserve {
     const LEN: usize = RESERVE_LEN;
 
@@ -737,7 +734,6 @@ impl Pack for Reserve {
             liquidity_mint_pubkey,
             liquidity_mint_decimals,
             liquidity_supply_pubkey,
-            liquidity_fee_receiver,
             liquidity_pyth_oracle_pubkey,
             liquidity_switchboard_oracle_pubkey,
             liquidity_available_amount,
@@ -759,6 +755,7 @@ impl Pack for Reserve {
             config_fees_host_fee_percentage,
             config_deposit_limit,
             config_borrow_limit,
+            config_fee_receiver,
             _padding,
         ) = mut_array_refs![
             output,
@@ -771,7 +768,6 @@ impl Pack for Reserve {
             PUBKEY_BYTES,
             PUBKEY_BYTES,
             PUBKEY_BYTES,
-            PUBKEY_BYTES,
             8,
             16,
             16,
@@ -791,6 +787,7 @@ impl Pack for Reserve {
             1,
             8,
             8,
+            PUBKEY_BYTES,
             248
         ];
 
@@ -804,7 +801,6 @@ impl Pack for Reserve {
         liquidity_mint_pubkey.copy_from_slice(self.liquidity.mint_pubkey.as_ref());
         *liquidity_mint_decimals = self.liquidity.mint_decimals.to_le_bytes();
         liquidity_supply_pubkey.copy_from_slice(self.liquidity.supply_pubkey.as_ref());
-        liquidity_fee_receiver.copy_from_slice(self.liquidity.fee_receiver.as_ref());
         liquidity_pyth_oracle_pubkey.copy_from_slice(self.liquidity.pyth_oracle_pubkey.as_ref());
         liquidity_switchboard_oracle_pubkey
             .copy_from_slice(self.liquidity.switchboard_oracle_pubkey.as_ref());
@@ -837,6 +833,7 @@ impl Pack for Reserve {
         *config_fees_host_fee_percentage = self.config.fees.host_fee_percentage.to_le_bytes();
         *config_deposit_limit = self.config.deposit_limit.to_le_bytes();
         *config_borrow_limit = self.config.borrow_limit.to_le_bytes();
+        config_fee_receiver.copy_from_slice(self.config.fee_receiver.as_ref());
     }
 
     /// Unpacks a byte buffer into a [ReserveInfo](struct.ReserveInfo.html).
@@ -851,7 +848,6 @@ impl Pack for Reserve {
             liquidity_mint_pubkey,
             liquidity_mint_decimals,
             liquidity_supply_pubkey,
-            liquidity_fee_receiver,
             liquidity_pyth_oracle_pubkey,
             liquidity_switchboard_oracle_pubkey,
             liquidity_available_amount,
@@ -873,6 +869,7 @@ impl Pack for Reserve {
             config_fees_host_fee_percentage,
             config_deposit_limit,
             config_borrow_limit,
+            config_fee_receiver,
             _padding,
         ) = array_refs![
             input,
@@ -885,7 +882,6 @@ impl Pack for Reserve {
             PUBKEY_BYTES,
             PUBKEY_BYTES,
             PUBKEY_BYTES,
-            PUBKEY_BYTES,
             8,
             16,
             16,
@@ -905,6 +901,7 @@ impl Pack for Reserve {
             1,
             8,
             8,
+            PUBKEY_BYTES,
             248
         ];
 
@@ -925,7 +922,6 @@ impl Pack for Reserve {
                 mint_pubkey: Pubkey::new_from_array(*liquidity_mint_pubkey),
                 mint_decimals: u8::from_le_bytes(*liquidity_mint_decimals),
                 supply_pubkey: Pubkey::new_from_array(*liquidity_supply_pubkey),
-                fee_receiver: Pubkey::new_from_array(*liquidity_fee_receiver),
                 pyth_oracle_pubkey: Pubkey::new_from_array(*liquidity_pyth_oracle_pubkey),
                 switchboard_oracle_pubkey: Pubkey::new_from_array(
                     *liquidity_switchboard_oracle_pubkey,
@@ -955,6 +951,7 @@ impl Pack for Reserve {
                 },
                 deposit_limit: u64::from_le_bytes(*config_deposit_limit),
                 borrow_limit: u64::from_le_bytes(*config_borrow_limit),
+                fee_receiver: Pubkey::new_from_array(*config_fee_receiver),
             },
         })
     }

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -42,7 +42,7 @@ async fn test_borrow_usdc_fixed_amount() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);
@@ -106,7 +106,7 @@ async fn test_borrow_usdc_fixed_amount() {
                 usdc_test_reserve.liquidity_supply_pubkey,
                 usdc_test_reserve.user_liquidity_pubkey,
                 usdc_test_reserve.pubkey,
-                usdc_test_reserve.liquidity_fee_receiver_pubkey,
+                usdc_test_reserve.config.fee_receiver,
                 test_obligation.pubkey,
                 lending_market.pubkey,
                 test_obligation.owner,
@@ -154,11 +154,8 @@ async fn test_borrow_usdc_fixed_amount() {
         initial_liquidity_supply - USDC_TOTAL_BORROW_FRACTIONAL
     );
 
-    let fee_balance = get_token_balance(
-        &mut banks_client,
-        usdc_test_reserve.liquidity_fee_receiver_pubkey,
-    )
-    .await;
+    let fee_balance =
+        get_token_balance(&mut banks_client, usdc_test_reserve.config.fee_receiver).await;
     assert_eq!(fee_balance, FEE_AMOUNT - HOST_FEE_AMOUNT);
 
     let host_fee_balance =
@@ -189,7 +186,7 @@ async fn test_borrow_sol_max_amount() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let usdc_mint = add_usdc_mint(&mut test);
@@ -253,7 +250,7 @@ async fn test_borrow_sol_max_amount() {
                 sol_test_reserve.liquidity_supply_pubkey,
                 sol_test_reserve.user_liquidity_pubkey,
                 sol_test_reserve.pubkey,
-                sol_test_reserve.liquidity_fee_receiver_pubkey,
+                sol_test_reserve.config.fee_receiver,
                 test_obligation.pubkey,
                 lending_market.pubkey,
                 test_obligation.owner,
@@ -295,11 +292,8 @@ async fn test_borrow_sol_max_amount() {
         initial_liquidity_supply - SOL_BORROW_AMOUNT_LAMPORTS
     );
 
-    let fee_balance = get_token_balance(
-        &mut banks_client,
-        sol_test_reserve.liquidity_fee_receiver_pubkey,
-    )
-    .await;
+    let fee_balance =
+        get_token_balance(&mut banks_client, sol_test_reserve.config.fee_receiver).await;
     assert_eq!(fee_balance, FEE_AMOUNT - HOST_FEE_AMOUNT);
 
     let host_fee_balance =
@@ -323,7 +317,7 @@ async fn test_borrow_too_large() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);
@@ -384,7 +378,7 @@ async fn test_borrow_too_large() {
                 usdc_test_reserve.liquidity_supply_pubkey,
                 usdc_test_reserve.user_liquidity_pubkey,
                 usdc_test_reserve.pubkey,
-                usdc_test_reserve.liquidity_fee_receiver_pubkey,
+                usdc_test_reserve.config.fee_receiver,
                 test_obligation.pubkey,
                 lending_market.pubkey,
                 test_obligation.owner,

--- a/token-lending/program/tests/deposit_obligation_collateral.rs
+++ b/token-lending/program/tests/deposit_obligation_collateral.rs
@@ -45,7 +45,7 @@ async fn test_success() {
             liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
             liquidity_mint_decimals: 9,
             liquidity_mint_pubkey: spl_token::native_mint::id(),
-            config: TEST_RESERVE_CONFIG,
+            config: test_reserve_config(),
             mark_fresh: true,
             ..AddReserveArgs::default()
         },

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -33,7 +33,7 @@ async fn test_success() {
             liquidity_amount: 10_000 * FRACTIONAL_TO_USDC,
             liquidity_mint_decimals: usdc_mint.decimals,
             liquidity_mint_pubkey: usdc_mint.pubkey,
-            config: TEST_RESERVE_CONFIG,
+            config: test_reserve_config(),
             mark_fresh: true,
             ..AddReserveArgs::default()
         },

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -42,7 +42,7 @@ async fn test_success() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.fees.flash_loan_fee_wad = 3_000_000_000_000_000;
 
     let usdc_mint = add_usdc_mint(&mut test);
@@ -91,7 +91,7 @@ async fn test_success() {
             usdc_test_reserve.liquidity_supply_pubkey,
             program_owned_token_account,
             usdc_test_reserve.pubkey,
-            usdc_test_reserve.liquidity_fee_receiver_pubkey,
+            usdc_test_reserve.config.fee_receiver,
             usdc_test_reserve.liquidity_host_pubkey,
             lending_market.pubkey,
             receiver_program_id.clone(),
@@ -127,11 +127,8 @@ async fn test_success() {
     let token_balance = get_token_balance(&mut banks_client, program_owned_token_account).await;
     assert_eq!(token_balance, initial_token_balance - FEE_AMOUNT);
 
-    let fee_balance = get_token_balance(
-        &mut banks_client,
-        usdc_test_reserve.liquidity_fee_receiver_pubkey,
-    )
-    .await;
+    let fee_balance =
+        get_token_balance(&mut banks_client, usdc_test_reserve.config.fee_receiver).await;
     assert_eq!(fee_balance, FEE_AMOUNT - HOST_FEE_AMOUNT);
 
     let host_fee_balance =
@@ -162,7 +159,7 @@ async fn test_failure() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.fees.flash_loan_fee_wad = 3_000_000_000_000_000;
 
     let usdc_mint = add_usdc_mint(&mut test);
@@ -203,7 +200,7 @@ async fn test_failure() {
             usdc_test_reserve.liquidity_supply_pubkey,
             program_owned_token_account,
             usdc_test_reserve.pubkey,
-            usdc_test_reserve.liquidity_fee_receiver_pubkey,
+            usdc_test_reserve.config.fee_receiver,
             usdc_test_reserve.liquidity_host_pubkey,
             lending_market.pubkey,
             flash_loan_receiver_program_id.clone(),

--- a/token-lending/program/tests/liquidate_obligation.rs
+++ b/token-lending/program/tests/liquidate_obligation.rs
@@ -43,7 +43,7 @@ async fn test_success() {
     let user_transfer_authority = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
     reserve_config.liquidation_threshold = 80;
     reserve_config.liquidation_bonus = 10;

--- a/token-lending/program/tests/obligation_end_to_end.rs
+++ b/token-lending/program/tests/obligation_end_to_end.rs
@@ -55,7 +55,7 @@ async fn test_success() {
 
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);
@@ -171,7 +171,7 @@ async fn test_success() {
                 usdc_test_reserve.liquidity_supply_pubkey,
                 usdc_test_reserve.user_liquidity_pubkey,
                 usdc_test_reserve.pubkey,
-                usdc_test_reserve.liquidity_fee_receiver_pubkey,
+                usdc_test_reserve.config.fee_receiver,
                 obligation_pubkey,
                 lending_market.pubkey,
                 user_accounts_owner_pubkey,
@@ -279,11 +279,8 @@ async fn test_success() {
     assert_eq!(obligation.deposits.len(), 0);
     assert_eq!(obligation.borrows.len(), 0);
 
-    let fee_balance = get_token_balance(
-        &mut banks_client,
-        usdc_test_reserve.liquidity_fee_receiver_pubkey,
-    )
-    .await;
+    let fee_balance =
+        get_token_balance(&mut banks_client, usdc_test_reserve.config.fee_receiver).await;
     assert_eq!(fee_balance, FEE_AMOUNT - HOST_FEE_AMOUNT);
 
     let host_fee_balance =

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -44,7 +44,7 @@ async fn test_success() {
             liquidity_amount: USDC_RESERVE_LIQUIDITY_FRACTIONAL,
             liquidity_mint_decimals: usdc_mint.decimals,
             liquidity_mint_pubkey: usdc_mint.pubkey,
-            config: TEST_RESERVE_CONFIG,
+            config: test_reserve_config(),
             mark_fresh: true,
             ..AddReserveArgs::default()
         },

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -40,7 +40,7 @@ async fn test_success() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     // Configure reserve to a fixed borrow rate of 1%

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -34,7 +34,7 @@ async fn test_success() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 80;
 
     // Configure reserve to a fixed borrow rate of 1%

--- a/token-lending/program/tests/repay_obligation_liquidity.rs
+++ b/token-lending/program/tests/repay_obligation_liquidity.rs
@@ -36,7 +36,7 @@ async fn test_success() {
     let user_transfer_authority = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -37,7 +37,7 @@ async fn test_withdraw_fixed_amount() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);
@@ -164,7 +164,7 @@ async fn test_withdraw_max_amount() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let usdc_mint = add_usdc_mint(&mut test);
@@ -270,7 +270,7 @@ async fn test_withdraw_too_large() {
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);
 
-    let mut reserve_config = TEST_RESERVE_CONFIG;
+    let mut reserve_config = test_reserve_config();
     reserve_config.loan_to_value_ratio = 50;
 
     let sol_oracle = add_sol_oracle(&mut test);


### PR DESCRIPTION
Moves the fee receiver from the ReserveLiquidity struct to the ReserveConfig struct
so that it can be modified by the update-reserve-config command, and because it 
makes more sense for it to be there.