### PR TITLE
Print Lending Market authority address and export in deploy script

### DIFF
--- a/deploy_token_lending.sh
+++ b/deploy_token_lending.sh
@@ -31,9 +31,9 @@ CREATE_MARKET_OUTPUT=`target/debug/spl-token-lending create-market \
 
 echo "$CREATE_MARKET_OUTPUT";
 MARKET_ADDR=`echo $CREATE_MARKET_OUTPUT | head -n1 | awk '{print $4}'`;
+AUTHORITY_ADDR=`echo $CREATE_MARKET_OUTPUT | grep "Authority Address" | awk '{print $NF}'`;
 
 echo "Creating SOL reserve";
-echo " -----$SOURCE -----"
 SOL_RESERVE_OUTPUT=`target/debug/spl-token-lending add-reserve \
   --fee-payer         $OWNER \
   --market-owner      $OWNER \
@@ -154,8 +154,7 @@ export BTC_MINT_ADDRESS="$BTC_TOKEN_MINT";
 
 # Main Market
 export MAIN_MARKET_ADDRESS="$MARKET_ADDR";
-export MAIN_MARKET_AUTHORITY_ADDRESS="TODO";
-export MAIN_MARKET_TRANSFER_AUTHORITY_ADDRESS="TODO";
+export MAIN_MARKET_AUTHORITY_ADDRESS="$AUTHORITY_ADDR";
 
 # Reserves
 export SOL_RESERVE_ADDRESS=`echo "$SOL_RESERVE_OUTPUT" | grep "Adding reserve" | awk '{print $NF}'`;

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -756,6 +756,15 @@ fn command_create_lending_market(
         recent_blockhash,
     );
     send_transaction(config, transaction)?;
+
+    let lending_market_pubkey = lending_market_keypair.pubkey();
+    let lending_market_account = config.rpc_client.get_account(&lending_market_pubkey)?;
+    let lending_market = LendingMarket::unpack_from_slice(lending_market_account.data.borrow())?;
+    let authority_signer_seeds = &[lending_market_pubkey.as_ref(), &[lending_market.bump_seed]];
+    println!(
+        "Authority Address {}",
+        Pubkey::create_program_address(authority_signer_seeds, &config.lending_program_id)?,
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Prints the lending market authority address so we don't have to do the stupid
thing where we look in the chrome logs for the error. 
Also exports it in the deploy script so that we can insert it into the config template.