### PR TITLE
Prepare for publishing

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,0 +1,14 @@
+anchor_version = "0.13.2"
+
+[workspace]
+members = [
+    "token-lending/program",
+    "token/program",
+]
+
+[provider]
+cluster = "mainnet"
+wallet = "~/.config/solana/id.json"
+
+[programs.mainnet]
+spl_token_lending = "<program-id-here>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,35 +1,7 @@
 [workspace]
 members = [
-  "associated-token-account/program",
-  "binary-oracle-pair/program",
-  "examples/rust/cross-program-invocation",
-  "examples/rust/custom-heap",
-  "examples/rust/logging",
-  "examples/rust/sysvar",
-  "examples/rust/transfer-lamports",
-  "feature-proposal/program",
-  "feature-proposal/cli",
-  "governance/program",
-  "libraries/math",
-  "memo/program",
-  "name-service/program",
-  "record/program",
-  "shared-memory/program",
-  "stake-pool/cli",
-  "stake-pool/program",
-  "token-lending/cli",
   "token-lending/program",
-  "token-swap/program",
-  "token-swap/program/fuzz",
-  "token/cli",
   "token/program",
-  "utils/cgen",
-  "utils/test-client",
-]
-exclude = [
-  "themis/client_ristretto",
-  "themis/program_ristretto",
-  "token/perf-monitor", # TODO: Rework perf-monitor to use solana-program-test, avoiding the need to link directly with the BPF VM
 ]
 
 [profile.dev]


### PR DESCRIPTION
Adds an Anchor.toml to publish a deterministic build to https://anchor.projectserum.com by running in the root of the repo

```bash
anchor publish spl_token_lending
```

Because this is a monorepo, in order to build any of the programs, all of them must be present. I've modified the Cargo.toml so that this isn't necessary. When you upload to the registry, only the code required to build the contract will be uploaded and displayed, instead of the entire repo. 

You probaly shouldn't merge the Cargo.toml changes, but you can refer to them for when you're ready to publish.