### PR TITLE
fix ci solana version

### DIFF
--- a/ci/solana-version.sh
+++ b/ci/solana-version.sh
@@ -14,7 +14,7 @@
 if [[ -n $SOLANA_VERSION ]]; then
   solana_version="$SOLANA_VERSION"
 else
-  solana_version=v1.7.12
+  solana_version=v1.8.12
 fi
 
 export solana_version="$solana_version"


### PR DESCRIPTION
@RealAwesomeness discovered that Solana `0.7.12` is no longer available for download which is causing our ci to fail.