### PR TITLE
Obligation_owner should be readonly

### DIFF
--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -1083,7 +1083,7 @@ pub fn withdraw_obligation_collateral_and_redeem_reserve_collateral(
             AccountMeta::new(destination_liquidity_pubkey, false),
             AccountMeta::new(reserve_collateral_mint_pubkey, false),
             AccountMeta::new(reserve_liquidity_supply_pubkey, false),
-            AccountMeta::new(obligation_owner_pubkey, true),
+            AccountMeta::new_readonly(obligation_owner_pubkey, true),
             AccountMeta::new_readonly(user_transfer_authority_pubkey, true),
             AccountMeta::new_readonly(sysvar::clock::id(), false),
             AccountMeta::new_readonly(spl_token::id(), false),


### PR DESCRIPTION
Issue: As in description `WithdrawObligationCollateralAndRedeemReserveCollateral` combines `WithdrawObligationCollateral` and `RedeemReserveCollateral`. While `obligation_owner` in `WithdrawObligationCollateral` is readonly, it is writable in `WithdrawObligationCollateralAndRedeemReserveCollateral`.

Solution: Update `obligation_owner` readonly in `WithdrawObligationCollateralAndRedeemReserveCollateral`