### PR TITLE
fix to support higher exponent for switchboard v2

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2428,7 +2428,7 @@ fn get_switchboard_price_v2(
         return Err(LendingError::InvalidOracleConfig.into());
     }
     let price = Decimal::from(price_switchboard_desc.mantissa as u128);
-    let exp = (10u64).checked_pow(price_switchboard_desc.scale).unwrap();
+    let exp = Decimal::from((10u128).checked_pow(price_switchboard_desc.scale).unwrap());
     price.try_div(exp)
 }
 

--- a/token-lending/program/tests/obligation_end_to_end.rs
+++ b/token-lending/program/tests/obligation_end_to_end.rs
@@ -291,7 +291,7 @@ async fn test_success2() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(148_000);
+    test.set_bpf_compute_max_units(156_000);
 
     const FEE_AMOUNT: u64 = 100;
     const HOST_FEE_AMOUNT: u64 = 20;


### PR DESCRIPTION
switchboard exponent supports up to 28 decimal places. we only supported up to 19. we now support up to 38