### PR TITLE
undo borrow limit and close factor change and cap liquidation amount

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -28,11 +28,7 @@ use solana_program::{
 };
 use spl_token::solana_program::instruction::AccountMeta;
 use spl_token::state::{Account, Mint};
-use std::{
-    cmp::{max, min},
-    convert::TryInto,
-    result::Result,
-};
+use std::{cmp::min, convert::TryInto, result::Result};
 use switchboard_program::{
     get_aggregator, get_aggregator_result, AggregatorState, RoundResult, SwitchboardAccountType,
 };
@@ -902,30 +898,8 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     obligation.deposited_value = deposited_value;
     obligation.borrowed_value = borrowed_value;
 
-    // Wednesday, June 22, 2022 12:00:00 PM GMT
-    let start_timestamp = 1655899200u64;
-    // Wednesday, June 28, 2022 8:00:00 AM GMT
-    let end_timestamp = 1656403200u64;
-    let current_timestamp = clock.unix_timestamp as u64;
-    let current_timestamp_in_range = min(max(start_timestamp, current_timestamp), end_timestamp);
-    let numerator = end_timestamp
-        .checked_sub(current_timestamp_in_range)
-        .ok_or(LendingError::MathOverflow)?;
-    let denominator = end_timestamp
-        .checked_sub(start_timestamp)
-        .ok_or(LendingError::MathOverflow)?;
-
-    let start_global_unhealthy_borrow_value = Decimal::from(120000000u64);
-    let end_global_unhealthy_borrow_value = Decimal::from(50000000u64);
-
-    let global_unhealthy_borrow_value = end_global_unhealthy_borrow_value.try_add(
-        start_global_unhealthy_borrow_value
-            .try_sub(end_global_unhealthy_borrow_value)?
-            .try_mul(numerator)?
-            .try_div(denominator)?,
-    )?;
-    let global_allowed_borrow_value =
-        global_unhealthy_borrow_value.try_sub(Decimal::from(5000000u64))?;
+    let global_unhealthy_borrow_value = Decimal::from(50000000u64);
+    let global_allowed_borrow_value = Decimal::from(45000000u64);
 
     obligation.allowed_borrow_value = min(allowed_borrow_value, global_allowed_borrow_value);
     obligation.unhealthy_borrow_value = min(unhealthy_borrow_value, global_unhealthy_borrow_value);

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -18,10 +18,10 @@ use std::{
 };
 
 /// Percentage of an obligation that can be repaid during each liquidation call
-pub const LIQUIDATION_CLOSE_FACTOR: u8 = 1;
+pub const LIQUIDATION_CLOSE_FACTOR: u8 = 20;
 
 /// Obligation borrow amount that is small enough to close out
-pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 20;
+pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 2;
 
 /// Lending market reserve state
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -21,7 +21,7 @@ use std::{
 pub const LIQUIDATION_CLOSE_FACTOR: u8 = 1;
 
 /// Obligation borrow amount that is small enough to close out
-pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 2;
+pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 20;
 
 /// Lending market reserve state
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -23,6 +23,9 @@ pub const LIQUIDATION_CLOSE_FACTOR: u8 = 1;
 /// Obligation borrow amount that is small enough to close out
 pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 2;
 
+/// Maximum quote currency value that can be liquidated in 1 liquidate_obligation call
+pub const MAX_LIQUIDATABLE_VALUE_AT_ONCE: u64 = 500_000;
+
 /// Lending market reserve state
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Reserve {


### PR DESCRIPTION
- undo sliding borrow limit
- set close factor back to 20%
- cap liquidation amount to a $500k to avoid hammering the market