### PR TITLE
cap liquidation amount for whales

### DIFF
--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -23,6 +23,9 @@ pub const LIQUIDATION_CLOSE_FACTOR: u8 = 1;
 /// Obligation borrow amount that is small enough to close out
 pub const LIQUIDATION_CLOSE_AMOUNT: u64 = 2;
 
+/// Maximum quote currency value that can be liquidated in 1 liquidate_obligation call
+pub const MAX_LIQUIDATABLE_VALUE_AT_ONCE: u64 = 500_000;
+
 /// Lending market reserve state
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Reserve {


### PR DESCRIPTION
Liquidations can be a maximum of 500k USD to avoid hammering the market when liquidating big positions