### PR TITLE
0xripleys outflow limits

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1,7 +1,7 @@
 use lending_state::SolendState;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_sdk::{commitment_config::CommitmentLevel, compute_budget::ComputeBudgetInstruction};
-use solend_program::state::SLOTS_PER_YEAR;
+use solend_program::state::{RateLimiterConfig, SLOTS_PER_YEAR};
 use solend_sdk::{
     instruction::{
         liquidate_obligation_and_redeem_reserve_collateral, redeem_reserve_collateral,
@@ -872,9 +872,6 @@ fn main() {
                     fee_receiver: liquidity_fee_receiver_keypair.pubkey(),
                     protocol_liquidation_fee,
                     protocol_take_rate,
-                    // FIXME: add support for rate limiter params
-                    window_duration: SLOTS_PER_YEAR / 365,
-                    max_outflow: u64::MAX,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,
@@ -1679,6 +1676,10 @@ fn command_update_reserve(
         &[update_reserve_config(
             config.lending_program_id,
             reserve.config,
+            RateLimiterConfig {
+                window_duration: SLOTS_PER_YEAR / 365,
+                max_outflow: u64::MAX,
+            },
             reserve_pubkey,
             lending_market_pubkey,
             lending_market_owner_keypair.pubkey(),

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1,6 +1,7 @@
 use lending_state::SolendState;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_sdk::{commitment_config::CommitmentLevel, compute_budget::ComputeBudgetInstruction};
+use solend_program::state::SLOTS_PER_YEAR;
 use solend_sdk::{
     instruction::{
         liquidate_obligation_and_redeem_reserve_collateral, redeem_reserve_collateral,
@@ -871,6 +872,9 @@ fn main() {
                     fee_receiver: liquidity_fee_receiver_keypair.pubkey(),
                     protocol_liquidation_fee,
                     protocol_take_rate,
+                    // FIXME: add support for rate limiter params
+                    window_duration: SLOTS_PER_YEAR / 365,
+                    max_outflow: u64::MAX,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -54,9 +54,17 @@ pub fn process_instruction(
             msg!("Instruction: Init Lending Market");
             process_init_lending_market(program_id, owner, quote_currency, accounts)
         }
-        LendingInstruction::SetLendingMarketOwnerAndConfig { new_owner, config } => {
+        LendingInstruction::SetLendingMarketOwnerAndConfig {
+            new_owner,
+            rate_limiter_config,
+        } => {
             msg!("Instruction: Set Lending Market Owner");
-            process_set_lending_market_owner_and_config(program_id, new_owner, config, accounts)
+            process_set_lending_market_owner_and_config(
+                program_id,
+                new_owner,
+                rate_limiter_config,
+                accounts,
+            )
         }
         LendingInstruction::InitReserve {
             liquidity_amount,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -231,8 +231,8 @@ fn process_set_lending_market_owner_and_config(
         )
     {
         lending_market.rate_limiter = RateLimiter::new(
-            Decimal::from(config.max_outflow),
             config.window_duration,
+            Decimal::from(config.max_outflow),
             Clock::get()?.slot,
         );
     }
@@ -2099,8 +2099,8 @@ fn process_update_reserve_config(
         != (config.window_duration, config.max_outflow)
     {
         let rate_limiter = RateLimiter::new(
-            Decimal::from(config.max_outflow),
             config.window_duration,
+            Decimal::from(config.max_outflow),
             Clock::get()?.slot,
         );
         reserve.rate_limiter = rate_limiter;

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2094,6 +2094,18 @@ fn process_update_reserve_config(
         return Err(LendingError::InvalidMarketAuthority.into());
     }
 
+    // if window duration and max outflow are different, then create a new rate limiter instance.
+    if (reserve.config.window_duration, reserve.config.max_outflow)
+        != (config.window_duration, config.max_outflow)
+    {
+        let rate_limiter = RateLimiter::new(
+            Decimal::from(config.max_outflow),
+            config.window_duration,
+            Clock::get()?.slot,
+        );
+        reserve.rate_limiter = rate_limiter;
+    }
+
     if *pyth_price_info.key != reserve.liquidity.pyth_oracle_pubkey {
         validate_pyth_keys(&lending_market, pyth_product_info, pyth_price_info)?;
         reserve.liquidity.pyth_oracle_pubkey = *pyth_price_info.key;

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -9,8 +9,8 @@ use crate::{
     state::{
         CalculateBorrowResult, CalculateLiquidationResult, CalculateRepayResult,
         InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
-        NewReserveCollateralParams, NewReserveLiquidityParams, Obligation,
-        Reserve, ReserveCollateral, ReserveConfig, ReserveLiquidity,
+        NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, Reserve,
+        ReserveCollateral, ReserveConfig, ReserveLiquidity,
     },
 };
 use pyth_sdk_solana::{self, state::ProductAccount};
@@ -129,7 +129,10 @@ pub fn process_instruction(
                 accounts,
             )
         }
-        LendingInstruction::UpdateReserveConfig { config, rate_limiter_config } => {
+        LendingInstruction::UpdateReserveConfig {
+            config,
+            rate_limiter_config,
+        } => {
             msg!("Instruction: UpdateReserveConfig");
             process_update_reserve_config(program_id, config, rate_limiter_config, accounts)
         }
@@ -2100,10 +2103,7 @@ fn process_update_reserve_config(
 
     // if window duration and max outflow are different, then create a new rate limiter instance.
     if rate_limiter_config != reserve.rate_limiter.config {
-        reserve.rate_limiter = RateLimiter::new(
-            rate_limiter_config,
-            Clock::get()?.slot,
-        );
+        reserve.rate_limiter = RateLimiter::new(rate_limiter_config, Clock::get()?.slot);
     }
 
     if *pyth_price_info.key != reserve.liquidity.pyth_oracle_pubkey {

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
+use solend_program::math::TryDiv;
 mod helpers;
 
 use solend_program::state::ReserveFees;
@@ -175,7 +176,12 @@ async fn test_success() {
             rate_limiter: {
                 let mut rate_limiter = lending_market.account.rate_limiter;
                 rate_limiter
-                    .update(1000, Decimal::from(10 * (4 * LAMPORTS_PER_SOL + 400)))
+                    .update(
+                        1000,
+                        Decimal::from(10 * (4 * LAMPORTS_PER_SOL + 400))
+                            .try_div(Decimal::from(1_000_000_000_u64))
+                            .unwrap(),
+                    )
                     .unwrap();
                 rate_limiter
             },

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -3,7 +3,7 @@
 use solend_program::math::TryDiv;
 mod helpers;
 
-use solend_program::state::{ReserveFees, RateLimiterConfig};
+use solend_program::state::{RateLimiterConfig, ReserveFees};
 use std::collections::HashSet;
 
 use helpers::solend_program_test::{
@@ -106,16 +106,24 @@ async fn setup(
 
 #[tokio::test]
 async fn test_success() {
-    let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation, host_fee_receiver, _) =
-        setup(&ReserveConfig {
-            fees: ReserveFees {
-                borrow_fee_wad: 100_000_000_000,
-                flash_loan_fee_wad: 0,
-                host_fee_percentage: 20,
-            },
-            ..test_reserve_config()
-        })
-        .await;
+    let (
+        mut test,
+        lending_market,
+        usdc_reserve,
+        wsol_reserve,
+        user,
+        obligation,
+        host_fee_receiver,
+        _,
+    ) = setup(&ReserveConfig {
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 0,
+            host_fee_percentage: 20,
+        },
+        ..test_reserve_config()
+    })
+    .await;
 
     let balance_checker = BalanceChecker::start(
         &mut test,
@@ -251,16 +259,24 @@ async fn test_success() {
 // FIXME this should really be a unit test
 #[tokio::test]
 async fn test_borrow_max() {
-    let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation, host_fee_receiver, _) =
-        setup(&ReserveConfig {
-            fees: ReserveFees {
-                borrow_fee_wad: 100_000_000_000,
-                flash_loan_fee_wad: 0,
-                host_fee_percentage: 20,
-            },
-            ..test_reserve_config()
-        })
-        .await;
+    let (
+        mut test,
+        lending_market,
+        usdc_reserve,
+        wsol_reserve,
+        user,
+        obligation,
+        host_fee_receiver,
+        _,
+    ) = setup(&ReserveConfig {
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 0,
+            host_fee_percentage: 20,
+        },
+        ..test_reserve_config()
+    })
+    .await;
 
     let balance_checker = BalanceChecker::start(
         &mut test,
@@ -349,11 +365,19 @@ async fn test_fail_borrow_over_reserve_borrow_limit() {
 
 #[tokio::test]
 async fn test_fail_reserve_borrow_rate_limit_exceeded() {
-    let (mut test, lending_market, _, wsol_reserve, user, obligation, host_fee_receiver, lending_market_owner) =
-        setup(&ReserveConfig {
-            ..test_reserve_config()
-        })
-        .await;
+    let (
+        mut test,
+        lending_market,
+        _,
+        wsol_reserve,
+        user,
+        obligation,
+        host_fee_receiver,
+        lending_market_owner,
+    ) = setup(&ReserveConfig {
+        ..test_reserve_config()
+    })
+    .await;
 
     // ie, within 10 slots, the maximum outflow is 1 SOL
     lending_market

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -166,8 +166,22 @@ async fn test_success() {
     assert_eq!(mint_supply_changes, HashSet::new());
 
     // check program state
-    let lending_market_post = test.load_account(lending_market.pubkey).await;
-    assert_eq!(lending_market, lending_market_post);
+    let lending_market_post = test
+        .load_account::<LendingMarket>(lending_market.pubkey)
+        .await;
+    assert_eq!(
+        lending_market_post.account,
+        LendingMarket {
+            rate_limiter: {
+                let mut rate_limiter = lending_market.account.rate_limiter;
+                rate_limiter
+                    .update(1000, Decimal::from(10 * (4 * LAMPORTS_PER_SOL + 400)))
+                    .unwrap();
+                rate_limiter
+            },
+            ..lending_market.account
+        }
+    );
 
     let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
     let expected_wsol_reserve_post = Reserve {

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -89,23 +89,25 @@ async fn test_success() {
     assert_eq!(lending_market.account, lending_market_post.account);
 
     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+    let expected_usdc_reserve_post = Reserve {
+        last_update: LastUpdate {
+            slot: 1000,
+            stale: true,
+        },
+        liquidity: ReserveLiquidity {
+            available_amount: usdc_reserve.account.liquidity.available_amount + 1_000_000,
+            ..usdc_reserve.account.liquidity
+        },
+        collateral: ReserveCollateral {
+            mint_total_supply: usdc_reserve.account.collateral.mint_total_supply + 1_000_000,
+            ..usdc_reserve.account.collateral
+        },
+        ..usdc_reserve.account
+    };
     assert_eq!(
-        usdc_reserve_post.account,
-        Reserve {
-            last_update: LastUpdate {
-                slot: 1000,
-                stale: true
-            },
-            liquidity: ReserveLiquidity {
-                available_amount: usdc_reserve.account.liquidity.available_amount + 1_000_000,
-                ..usdc_reserve.account.liquidity
-            },
-            collateral: ReserveCollateral {
-                mint_total_supply: usdc_reserve.account.collateral.mint_total_supply + 1_000_000,
-                ..usdc_reserve.account.collateral
-            },
-            ..usdc_reserve.account
-        }
+        usdc_reserve_post.account, expected_usdc_reserve_post,
+        "{:#?} {:#?}",
+        usdc_reserve_post.account, expected_usdc_reserve_post
     );
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -20,7 +20,7 @@ use solend_program::{
         init_obligation, liquidate_obligation, refresh_obligation, refresh_reserve,
         withdraw_obligation_collateral_and_redeem_reserve_collateral,
     },
-    state::{Obligation, ReserveConfig, ReserveFees, SLOTS_PER_YEAR},
+    state::{Obligation, ReserveConfig, ReserveFees},
 };
 
 use spl_token::state::Mint;

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -20,7 +20,7 @@ use solend_program::{
         init_obligation, liquidate_obligation, refresh_obligation, refresh_reserve,
         withdraw_obligation_collateral_and_redeem_reserve_collateral,
     },
-    state::{Obligation, ReserveConfig, ReserveFees},
+    state::{Obligation, ReserveConfig, ReserveFees, SLOTS_PER_YEAR},
 };
 
 use spl_token::state::Mint;
@@ -53,6 +53,8 @@ pub fn test_reserve_config() -> ReserveConfig {
         fee_receiver: Keypair::new().pubkey(),
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
+        window_duration: 120,
+        max_outflow: u64::MAX,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -53,8 +53,6 @@ pub fn test_reserve_config() -> ReserveConfig {
         fee_receiver: Keypair::new().pubkey(),
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
-        window_duration: 120,
-        max_outflow: u64::MAX,
     }
 }
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::helpers::*;
 use solana_program::native_token::LAMPORTS_PER_SOL;
-use solend_program::state::LendingMarketConfig;
+use solend_program::state::RateLimiterConfig;
 use solend_sdk::{instruction::update_reserve_config, NULL_PUBKEY};
 
 use pyth_sdk_solana::state::PROD_ACCT_SIZE;
@@ -633,6 +633,7 @@ impl Info<LendingMarket> {
         lending_market_owner: &User,
         reserve: &Info<Reserve>,
         config: ReserveConfig,
+        rate_limiter_config: RateLimiterConfig,
         oracle: Option<&Oracle>,
     ) -> Result<(), BanksClientError> {
         let default_oracle = test
@@ -646,6 +647,7 @@ impl Info<LendingMarket> {
         let instructions = [update_reserve_config(
             solend_program::id(),
             config,
+            rate_limiter_config,
             reserve.pubkey,
             self.pubkey,
             lending_market_owner.keypair.pubkey(),
@@ -1086,7 +1088,7 @@ impl Info<LendingMarket> {
         test: &mut SolendProgramTest,
         lending_market_owner: &User,
         new_owner: &Pubkey,
-        config: LendingMarketConfig,
+        config: RateLimiterConfig,
     ) -> Result<(), BanksClientError> {
         let instructions = [set_lending_market_owner_and_config(
             solend_program::id(),

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -872,8 +872,10 @@ impl Info<LendingMarket> {
         host_fee_receiver_pubkey: &Pubkey,
         liquidity_amount: u64,
     ) -> Result<(), BanksClientError> {
+        let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+
         let mut instructions = self
-            .build_refresh_instructions(test, obligation, Some(borrow_reserve))
+            .build_refresh_instructions(test, &obligation, Some(borrow_reserve))
             .await;
 
         instructions.push(borrow_obligation_liquidity(
@@ -1342,6 +1344,8 @@ pub async fn setup_world(
 }
 
 /// Scenario 1
+/// sol = $10
+/// usdc = $1
 /// LendingMarket
 /// - USDC Reserve
 /// - WSOL Reserve

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -12,11 +12,13 @@ use solana_sdk::signer::Signer;
 use solana_sdk::transaction::TransactionError;
 use solend_program::error::LendingError;
 use solend_program::instruction::init_lending_market;
-use solend_program::state::{LendingMarket, PROGRAM_VERSION};
+use solend_program::state::{LendingMarket, RateLimiter, PROGRAM_VERSION};
 
 #[tokio::test]
 async fn test_success() {
     let mut test = SolendProgramTest::start_new().await;
+    test.advance_clock_by_slots(1000).await;
+
     let lending_market_owner = User::new_with_balances(&mut test, &[]).await;
 
     let lending_market = test
@@ -33,6 +35,7 @@ async fn test_success() {
             token_program_id: spl_token::id(),
             oracle_program_id: mock_pyth_program::id(),
             switchboard_oracle_program_id: mock_pyth_program::id(),
+            rate_limiter: RateLimiter::default(),
         }
     );
 }
@@ -40,6 +43,8 @@ async fn test_success() {
 #[tokio::test]
 async fn test_already_initialized() {
     let mut test = SolendProgramTest::start_new().await;
+    test.advance_clock_by_slots(1000).await;
+
     let lending_market_owner = User::new_with_balances(&mut test, &[]).await;
 
     let keypair = Keypair::new();

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -176,8 +176,8 @@ async fn test_success() {
             },
             config: reserve_config,
             rate_limiter: RateLimiter::new(
-                Decimal::from(reserve_config.max_outflow),
                 reserve_config.window_duration,
+                Decimal::from(reserve_config.max_outflow),
                 1001
             )
         }
@@ -342,8 +342,8 @@ async fn test_update_reserve_config() {
         Reserve {
             config: new_reserve_config,
             rate_limiter: RateLimiter::new(
-                Decimal::from(new_reserve_config.max_outflow),
                 new_reserve_config.window_duration,
+                Decimal::from(new_reserve_config.max_outflow),
                 1000
             ),
             ..wsol_reserve.account

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -24,6 +24,7 @@ use solana_sdk::{
     transaction::TransactionError,
 };
 use solend_program::state::LastUpdate;
+use solend_program::state::RateLimiter;
 use solend_program::state::Reserve;
 use solend_program::state::ReserveCollateral;
 use solend_program::state::ReserveLiquidity;
@@ -172,7 +173,12 @@ async fn test_success() {
                 mint_total_supply: 1000,
                 supply_pubkey: reserve_collateral_supply_pubkey,
             },
-            config: reserve_config
+            config: reserve_config,
+            rate_limiter: RateLimiter::new(
+                Decimal::from(reserve_config.max_outflow),
+                reserve_config.window_duration,
+                1001
+            )
         }
     );
 }

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -30,6 +30,7 @@ use solend_program::state::ReserveCollateral;
 use solend_program::state::ReserveLiquidity;
 use solend_program::state::PROGRAM_VERSION;
 use solend_program::NULL_PUBKEY;
+
 use solend_program::{
     error::LendingError,
     instruction::init_reserve,
@@ -318,7 +319,12 @@ async fn test_update_reserve_config() {
         .await
         .unwrap();
 
-    let new_reserve_config = test_reserve_config();
+    let new_reserve_config = ReserveConfig {
+        max_outflow: 100,
+        window_duration: 50,
+        ..test_reserve_config()
+    };
+
     lending_market
         .update_reserve_config(
             &mut test,
@@ -335,6 +341,11 @@ async fn test_update_reserve_config() {
         wsol_reserve_post.account,
         Reserve {
             config: new_reserve_config,
+            rate_limiter: RateLimiter::new(
+                Decimal::from(new_reserve_config.max_outflow),
+                new_reserve_config.window_duration,
+                1000
+            ),
             ..wsol_reserve.account
         }
     );

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -339,10 +339,7 @@ async fn test_update_reserve_config() {
         wsol_reserve_post.account,
         Reserve {
             config: new_reserve_config,
-            rate_limiter: RateLimiter::new(
-                new_rate_limiter_config,
-                1000
-            ),
+            rate_limiter: RateLimiter::new(new_rate_limiter_config, 1000),
             ..wsol_reserve.account
         }
     );

--- a/token-lending/program/tests/outflow_rate_limits.rs
+++ b/token-lending/program/tests/outflow_rate_limits.rs
@@ -1,0 +1,227 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program::instruction::InstructionError;
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::signature::Signer;
+use solana_sdk::signer::keypair::Keypair;
+use solana_sdk::transaction::TransactionError;
+use solend_program::math::TryDiv;
+mod helpers;
+
+use crate::solend_program_test::MintSupplyChange;
+use helpers::solend_program_test::{
+    setup_world, BalanceChecker, Info, SolendProgramTest, TokenBalanceChange, User,
+};
+use solend_sdk::error::LendingError;
+use solend_sdk::math::Decimal;
+use solend_sdk::state::ObligationCollateral;
+use solend_sdk::state::{
+    LendingMarket, RateLimiterConfig, Reserve, ReserveCollateral, ReserveConfig, ReserveLiquidity,
+};
+use std::collections::HashSet;
+
+use crate::solend_program_test::scenario_1;
+use helpers::*;
+
+use solana_program_test::*;
+
+use solend_sdk::state::LastUpdate;
+use solend_sdk::state::Obligation;
+
+async fn setup(
+    wsol_reserve_config: &ReserveConfig,
+) -> (
+    SolendProgramTest,
+    Info<LendingMarket>,
+    Info<Reserve>,
+    Info<Reserve>,
+    User,
+    Info<Obligation>,
+    User,
+    User,
+    User,
+) {
+    let (mut test, lending_market, usdc_reserve, wsol_reserve, lending_market_owner, user) =
+        setup_world(&test_reserve_config(), wsol_reserve_config).await;
+
+    let obligation = lending_market
+        .init_obligation(&mut test, Keypair::new(), &user)
+        .await
+        .expect("This should succeed");
+
+    lending_market
+        .deposit(&mut test, &usdc_reserve, &user, 100_000_000)
+        .await
+        .expect("This should succeed");
+
+    let usdc_reserve = test.load_account(usdc_reserve.pubkey).await;
+
+    lending_market
+        .deposit_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, 100_000_000)
+        .await
+        .expect("This should succeed");
+
+    let wsol_depositor = User::new_with_balances(
+        &mut test,
+        &[
+            (&wsol_mint::id(), 5 * LAMPORTS_PER_SOL),
+            (&wsol_reserve.account.collateral.mint_pubkey, 0),
+        ],
+    )
+    .await;
+
+    lending_market
+        .deposit(
+            &mut test,
+            &wsol_reserve,
+            &wsol_depositor,
+            5 * LAMPORTS_PER_SOL,
+        )
+        .await
+        .unwrap();
+
+    // populate market price correctly
+    lending_market
+        .refresh_reserve(&mut test, &wsol_reserve)
+        .await
+        .unwrap();
+
+    // populate deposit value correctly.
+    let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+    lending_market
+        .refresh_obligation(&mut test, &obligation)
+        .await
+        .unwrap();
+
+    let lending_market = test.load_account(lending_market.pubkey).await;
+    let usdc_reserve = test.load_account(usdc_reserve.pubkey).await;
+    let wsol_reserve = test.load_account(wsol_reserve.pubkey).await;
+    let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+
+    let host_fee_receiver = User::new_with_balances(&mut test, &[(&wsol_mint::id(), 0)]).await;
+    (
+        test,
+        lending_market,
+        usdc_reserve,
+        wsol_reserve,
+        user,
+        obligation,
+        host_fee_receiver,
+        lending_market_owner,
+        wsol_depositor,
+    )
+}
+
+#[tokio::test]
+async fn test_outflow_reserve() {
+    let (
+        mut test,
+        lending_market,
+        usdc_reserve,
+        wsol_reserve,
+        user,
+        obligation,
+        host_fee_receiver,
+        lending_market_owner,
+        wsol_depositor,
+    ) = setup(&ReserveConfig {
+        ..test_reserve_config()
+    })
+    .await;
+
+    // ie, within 10 slots, the maximum outflow is $10
+    lending_market
+        .set_lending_market_owner_and_config(
+            &mut test,
+            &lending_market_owner,
+            &lending_market_owner.keypair.pubkey(),
+            RateLimiterConfig {
+                window_duration: 10,
+                max_outflow: 10,
+            },
+        )
+        .await
+        .unwrap();
+
+    // borrow max amount
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            &wsol_reserve,
+            &obligation,
+            &user,
+            &host_fee_receiver.get_account(&wsol_mint::id()).unwrap(),
+            LAMPORTS_PER_SOL,
+        )
+        .await
+        .unwrap();
+
+    // for the next 10 slots, we shouldn't be able to withdraw, borrow, or redeem anything.
+    let cur_slot = test.get_clock().await.slot;
+    for _ in cur_slot..(cur_slot + 10) {
+        let res = lending_market
+            .borrow_obligation_liquidity(
+                &mut test,
+                &wsol_reserve,
+                &obligation,
+                &user,
+                &host_fee_receiver.get_account(&wsol_mint::id()).unwrap(),
+                1,
+            )
+            .await
+            .err()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            res,
+            TransactionError::InstructionError(
+                3,
+                InstructionError::Custom(LendingError::OutflowRateLimitExceeded as u32)
+            )
+        );
+
+        let res = lending_market
+            .withdraw_obligation_collateral_and_redeem_reserve_collateral(
+                &mut test,
+                &usdc_reserve,
+                &obligation,
+                &user,
+                1,
+            )
+            .await
+            .err()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            res,
+            TransactionError::InstructionError(
+                3,
+                InstructionError::Custom(LendingError::OutflowRateLimitExceeded as u32)
+            )
+        );
+
+        let res = lending_market
+            .redeem(
+                &mut test,
+                &wsol_reserve,
+                &wsol_depositor,
+                1,
+            )
+            .await
+            .err()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            res,
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(LendingError::OutflowRateLimitExceeded as u32)
+            )
+        );
+
+        test.advance_clock_by_slots(1).await;
+    }
+}

--- a/token-lending/program/tests/outflow_rate_limits.rs
+++ b/token-lending/program/tests/outflow_rate_limits.rs
@@ -5,27 +5,18 @@ use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::signature::Signer;
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::transaction::TransactionError;
-use solend_program::math::TryDiv;
+
 mod helpers;
 
-use crate::solend_program_test::MintSupplyChange;
-use helpers::solend_program_test::{
-    setup_world, BalanceChecker, Info, SolendProgramTest, TokenBalanceChange, User,
-};
+use helpers::solend_program_test::{setup_world, Info, SolendProgramTest, User};
 use solend_sdk::error::LendingError;
-use solend_sdk::math::Decimal;
-use solend_sdk::state::ObligationCollateral;
-use solend_sdk::state::{
-    LendingMarket, RateLimiterConfig, Reserve, ReserveCollateral, ReserveConfig, ReserveLiquidity,
-};
-use std::collections::HashSet;
 
-use crate::solend_program_test::scenario_1;
+use solend_sdk::state::{LendingMarket, RateLimiterConfig, Reserve, ReserveConfig};
+
 use helpers::*;
 
 use solana_program_test::*;
 
-use solend_sdk::state::LastUpdate;
 use solend_sdk::state::Obligation;
 
 async fn setup(
@@ -203,12 +194,7 @@ async fn test_outflow_reserve() {
         );
 
         let res = lending_market
-            .redeem(
-                &mut test,
-                &wsol_reserve,
-                &wsol_depositor,
-                1,
-            )
+            .redeem(&mut test, &wsol_reserve, &wsol_depositor, 1)
             .await
             .err()
             .unwrap()

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -88,7 +88,19 @@ async fn test_success() {
     let lending_market_post = test
         .load_account::<LendingMarket>(lending_market.pubkey)
         .await;
-    assert_eq!(lending_market.account, lending_market_post.account);
+    assert_eq!(
+        lending_market_post.account,
+        LendingMarket {
+            rate_limiter: {
+                let mut rate_limiter = lending_market.account.rate_limiter;
+                rate_limiter
+                    .update(1000, Decimal::from(1_000_000u64))
+                    .unwrap();
+                rate_limiter
+            },
+            ..lending_market.account
+        }
+    );
 
     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
     assert_eq!(

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -93,9 +93,7 @@ async fn test_success() {
         LendingMarket {
             rate_limiter: {
                 let mut rate_limiter = lending_market.account.rate_limiter;
-                rate_limiter
-                    .update(1000, Decimal::from(1u64))
-                    .unwrap();
+                rate_limiter.update(1000, Decimal::from(1u64)).unwrap();
                 rate_limiter
             },
             ..lending_market.account

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -2,6 +2,7 @@
 
 mod helpers;
 
+use solend_sdk::math::Decimal;
 use crate::solend_program_test::MintSupplyChange;
 use std::collections::HashSet;
 
@@ -104,6 +105,14 @@ async fn test_success() {
             collateral: ReserveCollateral {
                 mint_total_supply: usdc_reserve.account.collateral.mint_total_supply - 1_000_000,
                 ..usdc_reserve.account.collateral
+            },
+            rate_limiter: {
+                let mut rate_limiter = usdc_reserve.account.rate_limiter;
+                rate_limiter
+                    .update(1000, Decimal::from(1_000_000u64))
+                    .unwrap();
+
+                rate_limiter
             },
             ..usdc_reserve.account
         }

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -94,7 +94,7 @@ async fn test_success() {
             rate_limiter: {
                 let mut rate_limiter = lending_market.account.rate_limiter;
                 rate_limiter
-                    .update(1000, Decimal::from(1_000_000u64))
+                    .update(1000, Decimal::from(1u64))
                     .unwrap();
                 rate_limiter
             },

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -2,8 +2,8 @@
 
 mod helpers;
 
-use solend_sdk::math::Decimal;
 use crate::solend_program_test::MintSupplyChange;
+use solend_sdk::math::Decimal;
 use std::collections::HashSet;
 
 use helpers::solend_program_test::{

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -142,9 +142,9 @@ async fn test_fail_redeem_too_much() {
 
     match res {
         // TokenError::Insufficient Funds
-        TransactionError::InstructionError(0, InstructionError::Custom(1)) => (),
+        TransactionError::InstructionError(1, InstructionError::Custom(1)) => (),
         // LendingError::TokenBurnFailed
-        TransactionError::InstructionError(0, InstructionError::Custom(19)) => (),
+        TransactionError::InstructionError(1, InstructionError::Custom(19)) => (),
         _ => panic!("Unexpected error: {:#?}", res),
     };
 }

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -240,6 +240,7 @@ async fn test_success_pyth_price_stale_switchboard_valid() {
             &lending_market_owner,
             &wsol_reserve,
             wsol_reserve.account.config,
+            wsol_reserve.account.rate_limiter.config,
             None,
         )
         .await

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -56,7 +56,7 @@ async fn test_success() {
         lending_market_post.account,
         LendingMarket {
             owner: new_owner.pubkey(),
-            rate_limiter: RateLimiter::new(Decimal::from(100u64), 5, 1000),
+            rate_limiter: RateLimiter::new(5, Decimal::from(100u64), 1000),
             ..lending_market_post.account
         }
     );

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -32,7 +32,7 @@ async fn setup() -> (SolendProgramTest, Info<LendingMarket>, User) {
 async fn test_success() {
     let (mut test, lending_market, lending_market_owner) = setup().await;
     let new_owner = Keypair::new();
-    let new_config = RateLimiterConfig{
+    let new_config = RateLimiterConfig {
         max_outflow: 100,
         window_duration: 5,
     };

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -101,7 +101,7 @@ async fn test_owner_not_signer() {
                 ],
                 data: LendingInstruction::SetLendingMarketOwnerAndConfig {
                     new_owner,
-                    config: RateLimiterConfig::default(),
+                    rate_limiter_config: RateLimiterConfig::default(),
                 }
                 .pack(),
             }],

--- a/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
@@ -4,6 +4,7 @@ mod helpers;
 
 use crate::solend_program_test::MintSupplyChange;
 use solend_sdk::math::Decimal;
+use solend_sdk::state::LendingMarket;
 use solend_sdk::state::ObligationCollateral;
 use solend_sdk::state::ReserveCollateral;
 use std::collections::HashSet;
@@ -73,6 +74,23 @@ async fn test_success() {
     );
 
     // check program state
+    let lending_market_post = test
+        .load_account::<LendingMarket>(lending_market.pubkey)
+        .await;
+    assert_eq!(
+        lending_market_post.account,
+        LendingMarket {
+            rate_limiter: {
+                let mut rate_limiter = lending_market.account.rate_limiter;
+                rate_limiter
+                    .update(1000, Decimal::from(withdraw_amount as u64))
+                    .unwrap();
+                rate_limiter
+            },
+            ..lending_market.account
+        }
+    );
+
     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
     assert_eq!(
         usdc_reserve_post.account,

--- a/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
+use solend_program::math::TryDiv;
 mod helpers;
 
 use crate::solend_program_test::MintSupplyChange;
@@ -83,7 +84,12 @@ async fn test_success() {
             rate_limiter: {
                 let mut rate_limiter = lending_market.account.rate_limiter;
                 rate_limiter
-                    .update(1000, Decimal::from(withdraw_amount as u64))
+                    .update(
+                        1000,
+                        Decimal::from(withdraw_amount as u64)
+                            .try_div(Decimal::from(1_000_000u64))
+                            .unwrap(),
+                    )
                     .unwrap();
                 rate_limiter
             },

--- a/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
@@ -2,8 +2,8 @@
 
 mod helpers;
 
-use solend_sdk::math::Decimal;
 use crate::solend_program_test::MintSupplyChange;
+use solend_sdk::math::Decimal;
 use solend_sdk::state::ObligationCollateral;
 use solend_sdk::state::ReserveCollateral;
 use std::collections::HashSet;

--- a/token-lending/sdk/src/error.rs
+++ b/token-lending/sdk/src/error.rs
@@ -192,6 +192,9 @@ pub enum LendingError {
     /// Deprecated instruction
     #[error("Instruction is deprecated")]
     DeprecatedInstruction,
+    /// Outflow Rate Limit Exceeded
+    #[error("Outflow Rate Limit Exceeded")]
+    OutflowRateLimitExceeded,
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -497,7 +497,9 @@ impl LendingInstruction {
                 let (borrow_limit, rest) = Self::unpack_u64(rest)?;
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
-                let (protocol_take_rate, _rest) = Self::unpack_u8(rest)?;
+                let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
+                let (window_duration, rest) = Self::unpack_u64(rest)?;
+                let (max_outflow, _rest) = Self::unpack_u64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -518,6 +520,8 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        window_duration,
+                        max_outflow,
                     },
                 }
             }
@@ -579,7 +583,10 @@ impl LendingInstruction {
                 let (borrow_limit, rest) = Self::unpack_u64(rest)?;
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
-                let (protocol_take_rate, _rest) = Self::unpack_u8(rest)?;
+                let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
+                let (window_duration, rest) = Self::unpack_u64(rest)?;
+                let (max_outflow, _rest) = Self::unpack_u64(rest)?;
+
                 Self::UpdateReserveConfig {
                     config: ReserveConfig {
                         optimal_utilization_rate,
@@ -599,6 +606,8 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        window_duration,
+                        max_outflow,
                     },
                 }
             }
@@ -716,6 +725,8 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        window_duration,
+                        max_outflow,
                     },
             } => {
                 buf.push(2);
@@ -735,6 +746,8 @@ impl LendingInstruction {
                 buf.extend_from_slice(&fee_receiver.to_bytes());
                 buf.extend_from_slice(&protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&protocol_take_rate.to_le_bytes());
+                buf.extend_from_slice(&window_duration.to_le_bytes());
+                buf.extend_from_slice(&max_outflow.to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -802,6 +815,8 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.fee_receiver.to_bytes());
                 buf.extend_from_slice(&config.protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&config.protocol_take_rate.to_le_bytes());
+                buf.extend_from_slice(&config.window_duration.to_le_bytes());
+                buf.extend_from_slice(&config.max_outflow.to_le_bytes());
             }
             Self::LiquidateObligationAndRedeemReserveCollateral { liquidity_amount } => {
                 buf.push(17);

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::LendingError,
-    state::{ReserveConfig, ReserveFees, RateLimiterConfig},
+    state::{RateLimiterConfig, ReserveConfig, ReserveFees},
 };
 use solana_program::{
     instruction::{AccountMeta, Instruction},
@@ -806,7 +806,10 @@ impl LendingInstruction {
                 buf.push(15);
                 buf.extend_from_slice(&collateral_amount.to_le_bytes());
             }
-            Self::UpdateReserveConfig { config, rate_limiter_config } => {
+            Self::UpdateReserveConfig {
+                config,
+                rate_limiter_config,
+            } => {
                 buf.push(16);
                 buf.extend_from_slice(&config.optimal_utilization_rate.to_le_bytes());
                 buf.extend_from_slice(&config.loan_to_value_ratio.to_le_bytes());
@@ -1360,7 +1363,11 @@ pub fn update_reserve_config(
     Instruction {
         program_id,
         accounts,
-        data: LendingInstruction::UpdateReserveConfig { config, rate_limiter_config }.pack(),
+        data: LendingInstruction::UpdateReserveConfig {
+            config,
+            rate_limiter_config,
+        }
+        .pack(),
     }
 }
 

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -45,7 +45,7 @@ pub enum LendingInstruction {
         /// The new owner
         new_owner: Pubkey,
         /// The new config
-        config: RateLimiterConfig,
+        rate_limiter_config: RateLimiterConfig,
     },
 
     // 2
@@ -487,7 +487,7 @@ impl LendingInstruction {
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
                 Self::SetLendingMarketOwnerAndConfig {
                     new_owner,
-                    config: RateLimiterConfig {
+                    rate_limiter_config: RateLimiterConfig {
                         window_duration,
                         max_outflow,
                     },
@@ -709,7 +709,10 @@ impl LendingInstruction {
                 buf.extend_from_slice(owner.as_ref());
                 buf.extend_from_slice(quote_currency.as_ref());
             }
-            Self::SetLendingMarketOwnerAndConfig { new_owner, config } => {
+            Self::SetLendingMarketOwnerAndConfig {
+                new_owner,
+                rate_limiter_config: config,
+            } => {
                 buf.push(1);
                 buf.extend_from_slice(new_owner.as_ref());
                 buf.extend_from_slice(&config.window_duration.to_le_bytes());
@@ -885,7 +888,7 @@ pub fn set_lending_market_owner_and_config(
     lending_market_pubkey: Pubkey,
     lending_market_owner: Pubkey,
     new_owner: Pubkey,
-    config: RateLimiterConfig,
+    rate_limiter_config: RateLimiterConfig,
 ) -> Instruction {
     Instruction {
         program_id,
@@ -893,7 +896,11 @@ pub fn set_lending_market_owner_and_config(
             AccountMeta::new(lending_market_pubkey, false),
             AccountMeta::new_readonly(lending_market_owner, true),
         ],
-        data: LendingInstruction::SetLendingMarketOwnerAndConfig { new_owner, config }.pack(),
+        data: LendingInstruction::SetLendingMarketOwnerAndConfig {
+            new_owner,
+            rate_limiter_config,
+        }
+        .pack(),
     }
 }
 

--- a/token-lending/sdk/src/state/lending_market.rs
+++ b/token-lending/sdk/src/state/lending_market.rs
@@ -25,6 +25,8 @@ pub struct LendingMarket {
     pub oracle_program_id: Pubkey,
     /// Oracle (Switchboard) program id
     pub switchboard_oracle_program_id: Pubkey,
+    /// Outflow rate limiter denominated in dollars
+    pub rate_limiter: RateLimiter,
 }
 
 impl LendingMarket {
@@ -44,6 +46,25 @@ impl LendingMarket {
         self.token_program_id = params.token_program_id;
         self.oracle_program_id = params.oracle_program_id;
         self.switchboard_oracle_program_id = params.switchboard_oracle_program_id;
+        self.rate_limiter = RateLimiter::default();
+    }
+}
+
+/// Lending market configuration parameters
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LendingMarketConfig {
+    /// Rate limiter window size in slots
+    pub window_duration: u64,
+    /// Rate limiter param. Max outflow of tokens in a window
+    pub max_outflow: u64,
+}
+
+impl Default for LendingMarketConfig {
+    fn default() -> Self {
+        Self {
+            window_duration: 1,
+            max_outflow: u64::MAX,
+        }
     }
 }
 
@@ -62,6 +83,8 @@ pub struct InitLendingMarketParams {
     pub oracle_program_id: Pubkey,
     /// Oracle (Switchboard) program id
     pub switchboard_oracle_program_id: Pubkey,
+    /// Current slot
+    pub current_slot: u64,
 }
 
 impl Sealed for LendingMarket {}
@@ -86,6 +109,7 @@ impl Pack for LendingMarket {
             token_program_id,
             oracle_program_id,
             switchboard_oracle_program_id,
+            rate_limiter,
             _padding,
         ) = mut_array_refs![
             output,
@@ -96,7 +120,8 @@ impl Pack for LendingMarket {
             PUBKEY_BYTES,
             PUBKEY_BYTES,
             PUBKEY_BYTES,
-            128
+            RATE_LIMITER_LEN,
+            128 - RATE_LIMITER_LEN
         ];
 
         *version = self.version.to_le_bytes();
@@ -106,6 +131,7 @@ impl Pack for LendingMarket {
         token_program_id.copy_from_slice(self.token_program_id.as_ref());
         oracle_program_id.copy_from_slice(self.oracle_program_id.as_ref());
         switchboard_oracle_program_id.copy_from_slice(self.switchboard_oracle_program_id.as_ref());
+        self.rate_limiter.pack_into_slice(rate_limiter);
     }
 
     /// Unpacks a byte buffer into a [LendingMarketInfo](struct.LendingMarketInfo.html)
@@ -120,6 +146,7 @@ impl Pack for LendingMarket {
             token_program_id,
             oracle_program_id,
             switchboard_oracle_program_id,
+            rate_limiter,
             _padding,
         ) = array_refs![
             input,
@@ -130,7 +157,8 @@ impl Pack for LendingMarket {
             PUBKEY_BYTES,
             PUBKEY_BYTES,
             PUBKEY_BYTES,
-            128
+            RATE_LIMITER_LEN,
+            128 - RATE_LIMITER_LEN
         ];
 
         let version = u8::from_le_bytes(*version);
@@ -147,6 +175,7 @@ impl Pack for LendingMarket {
             token_program_id: Pubkey::new_from_array(*token_program_id),
             oracle_program_id: Pubkey::new_from_array(*oracle_program_id),
             switchboard_oracle_program_id: Pubkey::new_from_array(*switchboard_oracle_program_id),
+            rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
         })
     }
 }

--- a/token-lending/sdk/src/state/lending_market.rs
+++ b/token-lending/sdk/src/state/lending_market.rs
@@ -50,24 +50,6 @@ impl LendingMarket {
     }
 }
 
-/// Lending market configuration parameters
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct LendingMarketConfig {
-    /// Rate limiter window size in slots
-    pub window_duration: u64,
-    /// Rate limiter param. Max outflow of tokens in a window
-    pub max_outflow: u64,
-}
-
-impl Default for LendingMarketConfig {
-    fn default() -> Self {
-        Self {
-            window_duration: 1,
-            max_outflow: u64::MAX,
-        }
-    }
-}
-
 /// Initialize a lending market
 pub struct InitLendingMarketParams {
     /// Bump seed for derived authority address

--- a/token-lending/sdk/src/state/mod.rs
+++ b/token-lending/sdk/src/state/mod.rs
@@ -3,14 +3,14 @@
 mod last_update;
 mod lending_market;
 mod obligation;
-mod reserve;
 mod rate_limiter;
+mod reserve;
 
 pub use last_update::*;
 pub use lending_market::*;
 pub use obligation::*;
-pub use reserve::*;
 pub use rate_limiter::*;
+pub use reserve::*;
 
 use crate::math::{Decimal, WAD};
 use solana_program::{msg, program_error::ProgramError};

--- a/token-lending/sdk/src/state/mod.rs
+++ b/token-lending/sdk/src/state/mod.rs
@@ -4,6 +4,7 @@ mod last_update;
 mod lending_market;
 mod obligation;
 mod reserve;
+mod rate_limiter;
 
 pub use last_update::*;
 pub use lending_market::*;

--- a/token-lending/sdk/src/state/mod.rs
+++ b/token-lending/sdk/src/state/mod.rs
@@ -10,6 +10,7 @@ pub use last_update::*;
 pub use lending_market::*;
 pub use obligation::*;
 pub use reserve::*;
+pub use rate_limiter::*;
 
 use crate::math::{Decimal, WAD};
 use solana_program::{msg, program_error::ProgramError};

--- a/token-lending/sdk/src/state/rate_limiter.rs
+++ b/token-lending/sdk/src/state/rate_limiter.rs
@@ -13,18 +13,19 @@ use solana_program::program_pack::{Pack, Sealed};
 /// guarantee: at any point, the outflow between [cur_slot - slot.window_duration, cur_slot]
 /// is less than 2x max_outflow.
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RateLimiter {
-    // parameters
-    max_outflow: Decimal,
-    window_duration: Slot,
+    /// max outflow per window duration
+    pub max_outflow: Decimal,
+    /// window duration in slots
+    pub window_duration: Slot,
 
     // state
     prev_window: Window,
     cur_window: Window,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Window {
     slot_start: u64,
     qty: Decimal,

--- a/token-lending/sdk/src/state/rate_limiter.rs
+++ b/token-lending/sdk/src/state/rate_limiter.rs
@@ -1,45 +1,55 @@
+use crate::state::{pack_decimal, unpack_decimal};
+use solana_program::program_pack::IsInitialized;
 use solana_program::{program_error::ProgramError, slot_history::Slot};
 
 use crate::{
     error::LendingError,
     math::{Decimal, TryAdd, TryDiv, TryMul, TrySub},
 };
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_program::program_pack::{Pack, Sealed};
 
 /// Sliding Window Rate limiter
 /// guarantee: at any point, the outflow between [cur_slot - slot.window_duration, cur_slot]
 /// is less than 2x max_outflow.
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RateLimiter {
     // parameters
     max_outflow: Decimal,
     window_duration: Slot,
 
     // state
-    prev_window: Option<Window>,
+    prev_window: Window,
     cur_window: Window,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 struct Window {
     slot_start: u64,
     qty: Decimal,
 }
 
 impl RateLimiter {
-    fn new(max_outflow: Decimal, window_duration: u64, cur_slot: u64) -> Self {
+    /// initialize rate limiter
+    pub fn new(max_outflow: Decimal, window_duration: u64, cur_slot: u64) -> Self {
+        let slot_start = cur_slot / window_duration * window_duration;
         Self {
             max_outflow,
             window_duration,
-            prev_window: None,
+            prev_window: Window {
+                slot_start: slot_start - 1,
+                qty: Decimal::zero(),
+            },
             cur_window: Window {
-                slot_start: cur_slot / window_duration * window_duration,
+                slot_start,
                 qty: Decimal::zero(),
             },
         }
     }
 
-    fn update(&mut self, cur_slot: u64, qty: Decimal) -> Result<(), ProgramError> {
+    /// update rate limiter with new quantity. errors if rate limit has been reached
+    pub fn update(&mut self, cur_slot: u64, qty: Decimal) -> Result<(), ProgramError> {
         assert!(cur_slot >= self.cur_window.slot_start);
 
         // floor wrt window duration
@@ -52,7 +62,7 @@ impl RateLimiter {
 
             // |<-prev window->|<-cur window->| (cur_slot is in here) |
             std::cmp::Ordering::Equal => {
-                self.prev_window = Some(self.cur_window);
+                self.prev_window = self.cur_window;
                 self.cur_window = Window {
                     slot_start,
                     qty: Decimal::zero(),
@@ -61,7 +71,10 @@ impl RateLimiter {
 
             // |<-prev window->|<-cur window->|<-cur window + 1->| ... | (cur_slot is in here) |
             std::cmp::Ordering::Greater => {
-                self.prev_window = None;
+                self.prev_window = Window {
+                    slot_start: self.cur_window.slot_start - 1,
+                    qty: Decimal::zero(),
+                };
                 self.cur_window = Window {
                     slot_start,
                     qty: Decimal::zero(),
@@ -69,19 +82,15 @@ impl RateLimiter {
             }
         };
 
-        let cur_outflow = match self.prev_window {
-            None => self.cur_window.qty,
-            Some(window) => {
-                // assume the prev_window's outflow is even distributed across the window
-                // this isn't true, but it's a good enough approximation
-                let prev_weight = Decimal::one().try_sub(
-                    Decimal::from(cur_slot - self.cur_window.slot_start + 1)
-                        .try_div(self.window_duration)?,
-                )?;
-
-                (prev_weight.try_mul(window.qty)?).try_add(self.cur_window.qty)?
-            }
-        };
+        // assume the prev_window's outflow is even distributed across the window
+        // this isn't true, but it's a good enough approximation
+        let prev_weight = Decimal::one().try_sub(
+            Decimal::from(cur_slot - self.cur_window.slot_start + 1)
+                .try_div(self.window_duration)?,
+        )?;
+        let cur_outflow = prev_weight
+            .try_mul(self.prev_window.qty)?
+            .try_add(self.cur_window.qty)?;
 
         if cur_outflow.try_add(qty)? > self.max_outflow {
             Err(LendingError::OutflowRateLimitExceeded.into())
@@ -98,11 +107,15 @@ mod test {
 
     #[test]
     fn test_rate_limiter() {
-        let mut rate_limiter = RateLimiter::new(Decimal::from(100u64), 10, 0);
+        let mut rate_limiter = RateLimiter::new(Decimal::from(100u64), 10, 10);
 
         // case 1: no prev window, all quantity is taken up in first slot
-        assert_eq!(rate_limiter.update(0, Decimal::from(100u64)), Ok(()));
-        for i in 1..10 {
+        assert_eq!(
+            rate_limiter.update(10, Decimal::from(101u64)),
+            Err(LendingError::OutflowRateLimitExceeded.into())
+        );
+        assert_eq!(rate_limiter.update(10, Decimal::from(100u64)), Ok(()));
+        for i in 11..20 {
             assert_eq!(
                 rate_limiter.update(i, Decimal::from(1u64)),
                 Err(LendingError::OutflowRateLimitExceeded.into())
@@ -111,7 +124,7 @@ mod test {
 
         // case 2: prev window qty affects cur window's allowed qty. exactly 10 qty frees up every
         // slot.
-        for i in 10..20 {
+        for i in 20..30 {
             assert_eq!(
                 rate_limiter.update(i, Decimal::from(11u64)),
                 Err(LendingError::OutflowRateLimitExceeded.into())
@@ -131,5 +144,68 @@ mod test {
             assert_eq!(rate_limiter.update(i, Decimal::from(10u64)), Ok(()));
         }
         println!("{:#?}", rate_limiter);
+    }
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new(Decimal::from(u64::MAX), 1, 1)
+    }
+}
+
+impl Sealed for RateLimiter {}
+
+impl IsInitialized for RateLimiter {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+}
+
+/// Size of RateLimiter when packed into account
+pub const RATE_LIMITER_LEN: usize = 72;
+impl Pack for RateLimiter {
+    const LEN: usize = RATE_LIMITER_LEN;
+
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        let dst = array_mut_ref![dst, 0, RATE_LIMITER_LEN];
+        let (
+            max_outflow_dst,
+            window_duration_dst,
+            prev_window_slot_start_dst,
+            prev_window_qty_dst,
+            cur_window_slot_start_dst,
+            cur_window_qty_dst,
+        ) = mut_array_refs![dst, 16, 8, 8, 16, 8, 16];
+        pack_decimal(self.max_outflow, max_outflow_dst);
+        *window_duration_dst = self.window_duration.to_le_bytes();
+        *prev_window_slot_start_dst = self.prev_window.slot_start.to_le_bytes();
+        pack_decimal(self.prev_window.qty, prev_window_qty_dst);
+        *cur_window_slot_start_dst = self.cur_window.slot_start.to_le_bytes();
+        pack_decimal(self.cur_window.qty, cur_window_qty_dst);
+    }
+
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        let src = array_ref![src, 0, RATE_LIMITER_LEN];
+        let (
+            max_outflow_src,
+            window_duration_src,
+            prev_window_slot_start_src,
+            prev_window_qty_src,
+            cur_window_slot_start_src,
+            cur_window_qty_src,
+        ) = array_refs![src, 16, 8, 8, 16, 8, 16];
+
+        Ok(Self {
+            max_outflow: unpack_decimal(max_outflow_src),
+            window_duration: u64::from_le_bytes(*window_duration_src),
+            prev_window: Window {
+                slot_start: u64::from_le_bytes(*prev_window_slot_start_src),
+                qty: unpack_decimal(prev_window_qty_src),
+            },
+            cur_window: Window {
+                slot_start: u64::from_le_bytes(*cur_window_slot_start_src),
+                qty: unpack_decimal(cur_window_qty_src),
+            },
+        })
     }
 }

--- a/token-lending/sdk/src/state/rate_limiter.rs
+++ b/token-lending/sdk/src/state/rate_limiter.rs
@@ -15,10 +15,11 @@ use solana_program::program_pack::{Pack, Sealed};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RateLimiter {
-    /// max outflow per window duration
-    pub max_outflow: Decimal,
     /// window duration in slots
     pub window_duration: Slot,
+
+    /// max outflow per window duration
+    pub max_outflow: Decimal,
 
     // state
     prev_window: Window,
@@ -33,7 +34,7 @@ struct Window {
 
 impl RateLimiter {
     /// initialize rate limiter
-    pub fn new(max_outflow: Decimal, window_duration: u64, cur_slot: u64) -> Self {
+    pub fn new(window_duration: u64, max_outflow: Decimal, cur_slot: u64) -> Self {
         let slot_start = cur_slot / window_duration * window_duration;
         Self {
             max_outflow,
@@ -108,7 +109,7 @@ mod test {
 
     #[test]
     fn test_rate_limiter() {
-        let mut rate_limiter = RateLimiter::new(Decimal::from(100u64), 10, 10);
+        let mut rate_limiter = RateLimiter::new(10, Decimal::from(100u64), 10);
 
         // case 1: no prev window, all quantity is taken up in first slot
         assert_eq!(
@@ -150,7 +151,7 @@ mod test {
 
 impl Default for RateLimiter {
     fn default() -> Self {
-        Self::new(Decimal::from(u64::MAX), 1, 1)
+        Self::new(1, Decimal::from(u64::MAX), 1)
     }
 }
 

--- a/token-lending/sdk/src/state/rate_limiter.rs
+++ b/token-lending/sdk/src/state/rate_limiter.rs
@@ -90,9 +90,9 @@ impl RateLimiter {
 
         // assume the prev_window's outflow is even distributed across the window
         // this isn't true, but it's a good enough approximation
-        let prev_weight = Decimal::one().try_sub(
-            Decimal::from(cur_slot - self.window_start + 1).try_div(self.config.window_duration)?,
-        )?;
+        let prev_weight = Decimal::from(self.config.window_duration)
+            .try_sub(Decimal::from(cur_slot - self.window_start + 1))?
+            .try_div(self.config.window_duration)?;
         let cur_outflow = prev_weight.try_mul(self.prev_qty)?.try_add(self.cur_qty)?;
 
         if cur_outflow.try_add(qty)? > Decimal::from(self.config.max_outflow) {

--- a/token-lending/sdk/src/state/rate_limiter.rs
+++ b/token-lending/sdk/src/state/rate_limiter.rs
@@ -1,0 +1,135 @@
+use solana_program::{program_error::ProgramError, slot_history::Slot};
+
+use crate::{
+    error::LendingError,
+    math::{Decimal, TryAdd, TryDiv, TryMul, TrySub},
+};
+
+/// Sliding Window Rate limiter
+/// guarantee: at any point, the outflow between [cur_slot - slot.window_duration, cur_slot]
+/// is less than 2x max_outflow.
+
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimiter {
+    // parameters
+    max_outflow: Decimal,
+    window_duration: Slot,
+
+    // state
+    prev_window: Option<Window>,
+    cur_window: Window,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Window {
+    slot_start: u64,
+    qty: Decimal,
+}
+
+impl RateLimiter {
+    fn new(max_outflow: Decimal, window_duration: u64, cur_slot: u64) -> Self {
+        Self {
+            max_outflow,
+            window_duration,
+            prev_window: None,
+            cur_window: Window {
+                slot_start: cur_slot / window_duration * window_duration,
+                qty: Decimal::zero(),
+            },
+        }
+    }
+
+    fn update(&mut self, cur_slot: u64, qty: Decimal) -> Result<(), ProgramError> {
+        assert!(cur_slot >= self.cur_window.slot_start);
+
+        // floor wrt window duration
+        let slot_start = cur_slot / self.window_duration * self.window_duration;
+
+        // update prev window, current window
+        match slot_start.cmp(&(self.cur_window.slot_start + self.window_duration)) {
+            // |<-prev window->|<-cur window (cur_slot is in here)->|
+            std::cmp::Ordering::Less => (),
+
+            // |<-prev window->|<-cur window->| (cur_slot is in here) |
+            std::cmp::Ordering::Equal => {
+                self.prev_window = Some(self.cur_window);
+                self.cur_window = Window {
+                    slot_start,
+                    qty: Decimal::zero(),
+                };
+            }
+
+            // |<-prev window->|<-cur window->|<-cur window + 1->| ... | (cur_slot is in here) |
+            std::cmp::Ordering::Greater => {
+                self.prev_window = None;
+                self.cur_window = Window {
+                    slot_start,
+                    qty: Decimal::zero(),
+                };
+            }
+        };
+
+        let cur_outflow = match self.prev_window {
+            None => self.cur_window.qty,
+            Some(window) => {
+                // assume the prev_window's outflow is even distributed across the window
+                // this isn't true, but it's a good enough approximation
+                let prev_weight = Decimal::one().try_sub(
+                    Decimal::from(cur_slot - self.cur_window.slot_start + 1)
+                        .try_div(self.window_duration)?,
+                )?;
+
+                (prev_weight.try_mul(window.qty)?).try_add(self.cur_window.qty)?
+            }
+        };
+
+        if cur_outflow.try_add(qty)? > self.max_outflow {
+            Err(LendingError::OutflowRateLimitExceeded.into())
+        } else {
+            self.cur_window.qty = self.cur_window.qty.try_add(qty)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiter() {
+        let mut rate_limiter = RateLimiter::new(Decimal::from(100u64), 10, 0);
+
+        // case 1: no prev window, all quantity is taken up in first slot
+        assert_eq!(rate_limiter.update(0, Decimal::from(100u64)), Ok(()));
+        for i in 1..10 {
+            assert_eq!(
+                rate_limiter.update(i, Decimal::from(1u64)),
+                Err(LendingError::OutflowRateLimitExceeded.into())
+            );
+        }
+
+        // case 2: prev window qty affects cur window's allowed qty. exactly 10 qty frees up every
+        // slot.
+        for i in 10..20 {
+            assert_eq!(
+                rate_limiter.update(i, Decimal::from(11u64)),
+                Err(LendingError::OutflowRateLimitExceeded.into())
+            );
+
+            assert_eq!(rate_limiter.update(i, Decimal::from(10u64)), Ok(()));
+
+            assert_eq!(
+                rate_limiter.update(i, Decimal::from(1u64)),
+                Err(LendingError::OutflowRateLimitExceeded.into())
+            );
+        }
+
+        // case 3: new slot is so far ahead, prev window is dropped
+        assert_eq!(rate_limiter.update(100, Decimal::from(10u64)), Ok(()));
+        for i in 101..109 {
+            assert_eq!(rate_limiter.update(i, Decimal::from(10u64)), Ok(()));
+        }
+        println!("{:#?}", rate_limiter);
+    }
+}

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -64,6 +64,18 @@ impl Reserve {
         self.rate_limiter = RateLimiter::new(params.rate_limiter_config, params.current_slot);
     }
 
+    /// find price of tokens in quote currency
+    pub fn market_value(&self, liquidity_amount: Decimal) -> Result<Decimal, ProgramError> {
+        self.liquidity
+            .market_price
+            .try_mul(liquidity_amount)?
+            .try_div(Decimal::from(
+                (10u128)
+                    .checked_pow(self.liquidity.mint_decimals as u32)
+                    .ok_or(LendingError::MathOverflow)?,
+            ))
+    }
+
     /// Record deposited liquidity and return amount of collateral tokens to mint
     pub fn deposit_liquidity(&mut self, liquidity_amount: u64) -> Result<u64, ProgramError> {
         let collateral_amount = self

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -62,8 +62,8 @@ impl Reserve {
         self.collateral = params.collateral;
         self.config = params.config;
         self.rate_limiter = RateLimiter::new(
-            Decimal::from(params.config.max_outflow),
             params.config.window_duration,
+            Decimal::from(params.config.max_outflow),
             params.current_slot,
         );
     }


### PR DESCRIPTION
On any borrow or redeem instruction, we now check that the quantity outflowing doesn't exceed some specified amount per time.

Main Changes:
1. added a sliding window rate limiter class
2. add a rate limiter to the Reserve object which tracks outflows in token denominations (eg 1 SOL)
3. Added a rate limiter to the LendingMarket object which tracks outflows in USD denominations
4. changed SetLendingMarketOwner to SetLendingMarketOwnerAndConfig
5. can reset rate limiter with new params via UpdateReserveConfig or SetLendingMarketOwnerAndConfig
6. Added a bpf test that makes sure you can't borrow over some certain rate limit over a 10 slot period
7. bpf test that verifies lending market rate limits across diff instructions (borrow, withdraw, redeem)


Other comments:
- redeem reserve collateral now requires the reserve to be refreshed
- liquidate instructions are not affected by this outflow rate limit
- lending market is now mutable on borrow, withdraw_obligation_and_redeem, redeem_reserve_collateral instructions