### PR TITLE
0xripleys borrow coefficient

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -872,7 +872,7 @@ fn main() {
                     fee_receiver: liquidity_fee_receiver_keypair.pubkey(),
                     protocol_liquidation_fee,
                     protocol_take_rate,
-                    borrow_weight_bps: 10000,
+                    added_borrow_weight_bps: 10000,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -872,6 +872,7 @@ fn main() {
                     fee_receiver: liquidity_fee_receiver_keypair.pubkey(),
                     protocol_liquidation_fee,
                     protocol_take_rate,
+                    borrow_weight_bps: 10000,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2877,10 +2877,6 @@ fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
         msg!("Protocol take rate must be in range [0, 100]");
         return Err(LendingError::InvalidConfig.into());
     }
-    if config.borrow_weight_bps < 10000 {
-        msg!("Borrow weight bps must be greater than 10000!");
-        return Err(LendingError::InvalidConfig.into());
-    }
     Ok(())
 }
 

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -964,7 +964,8 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         let market_value = borrow_reserve.market_value(liquidity.borrowed_amount_wads)?;
         liquidity.market_value = market_value;
 
-        borrowed_value = borrowed_value.try_add(market_value.try_mul(borrow_reserve.borrow_weight())?)?;
+        borrowed_value =
+            borrowed_value.try_add(market_value.try_mul(borrow_reserve.borrow_weight())?)?;
     }
 
     if account_info_iter.peek().is_some() {

--- a/token-lending/program/tests/borrow_weight.rs
+++ b/token-lending/program/tests/borrow_weight.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-bpf")]
 /// the borrow weight feature affects a bunch of instructions. All of those instructions are tested
 /// here for correctness.
-
 use crate::solend_program_test::setup_world;
 use crate::solend_program_test::BalanceChecker;
 use crate::solend_program_test::TokenBalanceChange;

--- a/token-lending/program/tests/borrow_weight.rs
+++ b/token-lending/program/tests/borrow_weight.rs
@@ -26,7 +26,7 @@ async fn test_refresh_obligation() {
     let (mut test, lending_market, _, _, _, obligation) = scenario_1(
         &test_reserve_config(),
         &ReserveConfig {
-            borrow_weight_bps: 20_000,
+            added_borrow_weight_bps: 10_000,
             ..test_reserve_config()
         },
     )
@@ -55,7 +55,7 @@ async fn test_borrow() {
     let (mut test, lending_market, usdc_reserve, wsol_reserve, _, _) = setup_world(
         &test_reserve_config(),
         &ReserveConfig {
-            borrow_weight_bps: 20_000,
+            added_borrow_weight_bps: 10_000,
             fees: ReserveFees {
                 borrow_fee_wad: 10_000_000_000_000_000, // 1%
                 host_fee_percentage: 20,
@@ -207,7 +207,7 @@ async fn test_liquidation() {
         setup_world(
             &test_reserve_config(),
             &ReserveConfig {
-                borrow_weight_bps: 10_000,
+                added_borrow_weight_bps: 0,
                 fees: ReserveFees {
                     borrow_fee_wad: 10_000_000_000_000_000, // 1%
                     host_fee_percentage: 20,
@@ -341,7 +341,7 @@ async fn test_liquidation() {
             &lending_market_owner,
             &wsol_reserve,
             ReserveConfig {
-                borrow_weight_bps: 11_000,
+                added_borrow_weight_bps: 1_000,
                 ..wsol_reserve.account.config
             },
             wsol_reserve.account.rate_limiter.config,

--- a/token-lending/program/tests/borrow_weight.rs
+++ b/token-lending/program/tests/borrow_weight.rs
@@ -1,0 +1,383 @@
+#![cfg(feature = "test-bpf")]
+/// the borrow weight feature affects a bunch of instructions. All of those instructions are tested
+/// here for correctness.
+
+use crate::solend_program_test::setup_world;
+use crate::solend_program_test::BalanceChecker;
+use crate::solend_program_test::TokenBalanceChange;
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+use solend_program::state::ReserveConfig;
+use solend_sdk::state::ReserveFees;
+mod helpers;
+
+use crate::solend_program_test::scenario_1;
+use crate::solend_program_test::User;
+use helpers::*;
+use solana_program_test::*;
+use solana_sdk::signature::Keypair;
+use solend_program::math::Decimal;
+use solend_program::state::Obligation;
+use std::collections::HashSet;
+
+#[tokio::test]
+async fn test_refresh_obligation() {
+    let (mut test, lending_market, _, _, _, obligation) = scenario_1(
+        &test_reserve_config(),
+        &ReserveConfig {
+            borrow_weight_bps: 20_000,
+            ..test_reserve_config()
+        },
+    )
+    .await;
+
+    lending_market
+        .refresh_obligation(&mut test, &obligation)
+        .await
+        .unwrap();
+
+    let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+
+    // obligation has borrowed 10 sol and sol = $10 but since borrow weight == 2, the
+    // borrowed_value is 200 instead of 100.
+    assert_eq!(
+        obligation_post.account,
+        Obligation {
+            borrowed_value: Decimal::from(200u64),
+            ..obligation.account
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_borrow() {
+    let (mut test, lending_market, usdc_reserve, wsol_reserve, _, _) = setup_world(
+        &test_reserve_config(),
+        &ReserveConfig {
+            borrow_weight_bps: 20_000,
+            fees: ReserveFees {
+                borrow_fee_wad: 10_000_000_000_000_000, // 1%
+                host_fee_percentage: 20,
+                flash_loan_fee_wad: 0,
+            },
+            ..test_reserve_config()
+        },
+    )
+    .await;
+
+    // create obligation with 100 USDC deposited.
+    let (user, obligation) = {
+        let user = User::new_with_balances(
+            &mut test,
+            &[
+                (&usdc_mint::id(), 200 * FRACTIONAL_TO_USDC),
+                (&usdc_reserve.account.collateral.mint_pubkey, 0),
+                (&wsol_mint::id(), 0),
+            ],
+        )
+        .await;
+
+        let obligation = lending_market
+            .init_obligation(&mut test, Keypair::new(), &user)
+            .await
+            .expect("This should succeed");
+
+        lending_market
+            .deposit_reserve_liquidity_and_obligation_collateral(
+                &mut test,
+                &usdc_reserve,
+                &obligation,
+                &user,
+                100 * FRACTIONAL_TO_USDC,
+            )
+            .await
+            .unwrap();
+        (user, obligation)
+    };
+
+    // deposit 100 WSOL into reserve
+    let host_fee_receiver = {
+        let wsol_depositor = User::new_with_balances(
+            &mut test,
+            &[
+                (&wsol_mint::id(), 5 * LAMPORTS_PER_SOL),
+                (&wsol_reserve.account.collateral.mint_pubkey, 0),
+            ],
+        )
+        .await;
+
+        lending_market
+            .deposit(
+                &mut test,
+                &wsol_reserve,
+                &wsol_depositor,
+                5 * LAMPORTS_PER_SOL,
+            )
+            .await
+            .unwrap();
+
+        wsol_depositor.get_account(&wsol_mint::id()).unwrap()
+    };
+
+    // borrow max amount of SOL
+    {
+        lending_market
+            .borrow_obligation_liquidity(
+                &mut test,
+                &wsol_reserve,
+                &obligation,
+                &user,
+                &host_fee_receiver,
+                u64::MAX,
+            )
+            .await
+            .unwrap();
+
+        let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+        // - usdc ltv is 0.5,
+        // - sol borrow weight is 2
+        // max you can borrow is 100 * 0.5 / 2 = 2.5 SOL
+        assert_eq!(
+            obligation_post.account.borrows[0].borrowed_amount_wads,
+            Decimal::from(LAMPORTS_PER_SOL * 25 / 10)
+        );
+    }
+
+    // check that we shouldn't be able to withdraw anything
+    {
+        let res = lending_market
+            .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
+            .await
+            .err()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            res,
+            TransactionError::InstructionError(
+                3,
+                InstructionError::Custom(LendingError::WithdrawTooLarge as u32)
+            )
+        );
+    }
+
+    // deposit another 50 USDC
+    lending_market
+        .deposit_reserve_liquidity_and_obligation_collateral(
+            &mut test,
+            &usdc_reserve,
+            &obligation,
+            &user,
+            50 * FRACTIONAL_TO_USDC,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    // max withdraw
+    {
+        let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;
+
+        lending_market
+            .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
+            .await
+            .unwrap();
+
+        let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+        // should only be able to withdraw 50 USDC because the rest is needed to collateralize the
+        // SOL borrow
+        assert_eq!(
+            balance_changes,
+            HashSet::from([TokenBalanceChange {
+                token_account: user
+                    .get_account(&usdc_reserve.account.collateral.mint_pubkey)
+                    .unwrap(),
+                mint: usdc_reserve.account.collateral.mint_pubkey,
+                diff: (50 * FRACTIONAL_TO_USDC - 1) as i128,
+            }])
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_liquidation() {
+    let (mut test, lending_market, usdc_reserve, wsol_reserve, lending_market_owner, _) =
+        setup_world(
+            &test_reserve_config(),
+            &ReserveConfig {
+                borrow_weight_bps: 10_000,
+                fees: ReserveFees {
+                    borrow_fee_wad: 10_000_000_000_000_000, // 1%
+                    host_fee_percentage: 20,
+                    flash_loan_fee_wad: 0,
+                },
+                ..test_reserve_config()
+            },
+        )
+        .await;
+
+    // create obligation with 100 USDC deposited.
+    let (user, obligation) = {
+        let user = User::new_with_balances(
+            &mut test,
+            &[
+                (&usdc_mint::id(), 200 * FRACTIONAL_TO_USDC),
+                (&usdc_reserve.account.collateral.mint_pubkey, 0),
+                (&wsol_mint::id(), 0),
+            ],
+        )
+        .await;
+
+        let obligation = lending_market
+            .init_obligation(&mut test, Keypair::new(), &user)
+            .await
+            .expect("This should succeed");
+
+        lending_market
+            .deposit_reserve_liquidity_and_obligation_collateral(
+                &mut test,
+                &usdc_reserve,
+                &obligation,
+                &user,
+                100 * FRACTIONAL_TO_USDC,
+            )
+            .await
+            .unwrap();
+        (user, obligation)
+    };
+
+    // deposit 100 WSOL into reserve
+    let host_fee_receiver = {
+        let wsol_depositor = User::new_with_balances(
+            &mut test,
+            &[
+                (&wsol_mint::id(), 5 * LAMPORTS_PER_SOL),
+                (&wsol_reserve.account.collateral.mint_pubkey, 0),
+            ],
+        )
+        .await;
+
+        lending_market
+            .deposit(
+                &mut test,
+                &wsol_reserve,
+                &wsol_depositor,
+                5 * LAMPORTS_PER_SOL,
+            )
+            .await
+            .unwrap();
+
+        wsol_depositor.get_account(&wsol_mint::id()).unwrap()
+    };
+
+    // borrow max amount of SOL
+    {
+        lending_market
+            .borrow_obligation_liquidity(
+                &mut test,
+                &wsol_reserve,
+                &obligation,
+                &user,
+                &host_fee_receiver,
+                u64::MAX,
+            )
+            .await
+            .unwrap();
+
+        let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+        // - usdc ltv is 0.5,
+        // - sol borrow weight is 1
+        // max you can borrow is 100 * 0.5 = 5 SOL
+        assert_eq!(
+            obligation_post.account.borrows[0].borrowed_amount_wads,
+            Decimal::from(LAMPORTS_PER_SOL * 5)
+        );
+    }
+
+    let liquidator = User::new_with_balances(
+        &mut test,
+        &[
+            (&wsol_mint::id(), 100 * LAMPORTS_TO_SOL),
+            (&usdc_reserve.account.collateral.mint_pubkey, 0),
+            (&usdc_mint::id(), 0),
+        ],
+    )
+    .await;
+
+    // liquidating now would clearly fail because the obligation is healthy
+    {
+        let res = lending_market
+            .liquidate_obligation_and_redeem_reserve_collateral(
+                &mut test,
+                &wsol_reserve,
+                &usdc_reserve,
+                &obligation,
+                &liquidator,
+                u64::MAX,
+            )
+            .await
+            .err()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            res,
+            TransactionError::InstructionError(
+                3,
+                InstructionError::Custom(LendingError::ObligationHealthy as u32)
+            )
+        );
+    }
+
+    // what is the minimum borrow weight we need for the obligation to be eligible for liquidation?
+    // 100 * 0.55 = 5 * 10 * borrow_weight
+    // => borrow_weight = 1.1
+
+    // set borrow weight to 1.1
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &wsol_reserve,
+            ReserveConfig {
+                borrow_weight_bps: 11_000,
+                ..wsol_reserve.account.config
+            },
+            wsol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    // liquidating now should work
+    {
+        let balance_checker = BalanceChecker::start(&mut test, &[&liquidator]).await;
+        lending_market
+            .liquidate_obligation_and_redeem_reserve_collateral(
+                &mut test,
+                &wsol_reserve,
+                &usdc_reserve,
+                &obligation,
+                &liquidator,
+                u64::MAX,
+            )
+            .await
+            .unwrap();
+
+        // how much should be liquidated?
+        // => borrow value * close factor
+        // (5 sol * $10 * 1.1) * 0.2 = 11 usd worth of sol => repay ~1.1 sol (approximate because
+        // there is 1 slot worth of interest that is unaccounted for)
+        // note that if there were no borrow weight, we would only liquidate 10 usdc.
+        let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+        assert!(balance_changes.contains(&TokenBalanceChange {
+            token_account: liquidator.get_account(&wsol_mint::id()).unwrap(),
+            mint: wsol_mint::id(),
+            diff: -1100000002 // ~1.1 SOL
+        }));
+    }
+}

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -53,6 +53,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         fee_receiver: Keypair::new().pubkey(),
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
+        borrow_weight_bps: 10_000,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -53,7 +53,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         fee_receiver: Keypair::new().pubkey(),
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
-        borrow_weight_bps: 10_000,
+        added_borrow_weight_bps: 0,
     }
 }
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -805,6 +805,7 @@ impl Info<LendingMarket> {
         obligation: &Info<Obligation>,
         extra_reserve: Option<&Info<Reserve>>,
     ) -> Vec<Instruction> {
+        let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
         let reserve_pubkeys: Vec<Pubkey> = {
             let mut r = HashSet::new();
             r.extend(

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -300,35 +300,6 @@ async fn test_invalid_fees() {
 }
 
 #[tokio::test]
-async fn test_init_reserve_invalid_borrow_weight_bps() {
-    let (mut test, lending_market, lending_market_owner) = setup().await;
-    let res = test
-        .init_reserve(
-            &lending_market,
-            &lending_market_owner,
-            &usdc_mint::id(),
-            &ReserveConfig {
-                borrow_weight_bps: 9999,
-                ..test_reserve_config()
-            },
-            &Keypair::new(),
-            1000,
-            None,
-        )
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        res,
-        TransactionError::InstructionError(
-            1,
-            InstructionError::Custom(LendingError::InvalidConfig as u32)
-        )
-    );
-}
-
-#[tokio::test]
 async fn test_update_reserve_config() {
     let (mut test, lending_market, lending_market_owner) = setup().await;
 
@@ -421,59 +392,6 @@ async fn test_update_invalid_oracle_config() {
         TransactionError::InstructionError(
             0,
             InstructionError::Custom(LendingError::InvalidOracleConfig as u32)
-        )
-    );
-}
-
-#[tokio::test]
-async fn test_update_invalid_reserve_config_bad_borrow_weight_bps() {
-    let (mut test, lending_market, lending_market_owner) = setup().await;
-    let wsol_reserve = test
-        .init_reserve(
-            &lending_market,
-            &lending_market_owner,
-            &wsol_mint::id(),
-            &test_reserve_config(),
-            &Keypair::new(),
-            1000,
-            None,
-        )
-        .await
-        .unwrap();
-
-    let oracle = test.mints.get(&wsol_mint::id()).unwrap().unwrap();
-
-    let new_reserve_config = ReserveConfig {
-        borrow_weight_bps: 9999,
-        ..test_reserve_config()
-    };
-    let new_rate_limiter_config = RateLimiterConfig {
-        window_duration: 50,
-        max_outflow: 100,
-    };
-
-    let res = lending_market
-        .update_reserve_config(
-            &mut test,
-            &lending_market_owner,
-            &wsol_reserve,
-            new_reserve_config,
-            new_rate_limiter_config,
-            Some(&Oracle {
-                pyth_product_pubkey: oracle.pyth_product_pubkey,
-                pyth_price_pubkey: oracle.pyth_price_pubkey,
-                switchboard_feed_pubkey: Some(NULL_PUBKEY),
-            }),
-        )
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        res,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(LendingError::InvalidConfig as u32)
         )
     );
 }

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -300,6 +300,35 @@ async fn test_invalid_fees() {
 }
 
 #[tokio::test]
+async fn test_init_reserve_invalid_borrow_weight_bps() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+    let res = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &usdc_mint::id(),
+            &ReserveConfig {
+                borrow_weight_bps: 9999,
+                ..test_reserve_config()
+            },
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        res,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(LendingError::InvalidConfig as u32)
+        )
+    );
+}
+
+#[tokio::test]
 async fn test_update_reserve_config() {
     let (mut test, lending_market, lending_market_owner) = setup().await;
 
@@ -392,6 +421,59 @@ async fn test_update_invalid_oracle_config() {
         TransactionError::InstructionError(
             0,
             InstructionError::Custom(LendingError::InvalidOracleConfig as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn test_update_invalid_reserve_config_bad_borrow_weight_bps() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+    let wsol_reserve = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &wsol_mint::id(),
+            &test_reserve_config(),
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let oracle = test.mints.get(&wsol_mint::id()).unwrap().unwrap();
+
+    let new_reserve_config = ReserveConfig {
+        borrow_weight_bps: 9999,
+        ..test_reserve_config()
+    };
+    let new_rate_limiter_config = RateLimiterConfig {
+        window_duration: 50,
+        max_outflow: 100,
+    };
+
+    let res = lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &wsol_reserve,
+            new_reserve_config,
+            new_rate_limiter_config,
+            Some(&Oracle {
+                pyth_product_pubkey: oracle.pyth_product_pubkey,
+                pyth_price_pubkey: oracle.pyth_price_pubkey,
+                switchboard_feed_pubkey: Some(NULL_PUBKEY),
+            }),
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        res,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidConfig as u32)
         )
     );
 }

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -510,7 +510,7 @@ impl LendingInstruction {
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
                 let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
-                let (borrow_weight_bps, _rest) = Self::unpack_u64(rest)?;
+                let (added_borrow_weight_bps, _rest) = Self::unpack_u64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -531,7 +531,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps,
+                        added_borrow_weight_bps,
                     },
                 }
             }
@@ -594,7 +594,7 @@ impl LendingInstruction {
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
                 let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
-                let (borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
+                let (added_borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
 
@@ -617,7 +617,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps,
+                        added_borrow_weight_bps,
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -744,7 +744,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps,
+                        added_borrow_weight_bps: borrow_weight_bps,
                     },
             } => {
                 buf.push(2);
@@ -835,7 +835,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.fee_receiver.to_bytes());
                 buf.extend_from_slice(&config.protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&config.protocol_take_rate.to_le_bytes());
-                buf.extend_from_slice(&config.borrow_weight_bps.to_le_bytes());
+                buf.extend_from_slice(&config.added_borrow_weight_bps.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -531,7 +531,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps
+                        borrow_weight_bps,
                     },
                 }
             }
@@ -617,7 +617,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps
+                        borrow_weight_bps,
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -744,7 +744,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
-                        borrow_weight_bps
+                        borrow_weight_bps,
                     },
             } => {
                 buf.push(2);

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -509,7 +509,8 @@ impl LendingInstruction {
                 let (borrow_limit, rest) = Self::unpack_u64(rest)?;
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
-                let (protocol_take_rate, _rest) = Self::unpack_u8(rest)?;
+                let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
+                let (borrow_weight_bps, _rest) = Self::unpack_u64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -530,6 +531,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        borrow_weight_bps
                     },
                 }
             }
@@ -592,6 +594,7 @@ impl LendingInstruction {
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
                 let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
+                let (borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
 
@@ -614,6 +617,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        borrow_weight_bps
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -740,6 +744,7 @@ impl LendingInstruction {
                         fee_receiver,
                         protocol_liquidation_fee,
                         protocol_take_rate,
+                        borrow_weight_bps
                     },
             } => {
                 buf.push(2);
@@ -759,6 +764,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&fee_receiver.to_bytes());
                 buf.extend_from_slice(&protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&protocol_take_rate.to_le_bytes());
+                buf.extend_from_slice(&borrow_weight_bps.to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -829,6 +835,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.fee_receiver.to_bytes());
                 buf.extend_from_slice(&config.protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&config.protocol_take_rate.to_le_bytes());
+                buf.extend_from_slice(&config.borrow_weight_bps.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }

--- a/token-lending/sdk/src/math/common.rs
+++ b/token-lending/sdk/src/math/common.rs
@@ -10,6 +10,8 @@ pub const WAD: u64 = 1_000_000_000_000_000_000;
 pub const HALF_WAD: u64 = 500_000_000_000_000_000;
 /// Scale for percentages
 pub const PERCENT_SCALER: u64 = 10_000_000_000_000_000;
+/// Scale for basis points
+pub const BPS_SCALER: u64 = 100_000_000_000_000;
 
 /// Try to subtract, return an error on underflow
 pub trait TrySub: Sized {

--- a/token-lending/sdk/src/math/decimal.rs
+++ b/token-lending/sdk/src/math/decimal.rs
@@ -55,6 +55,11 @@ impl Decimal {
         Self(U192::from(percent as u64 * PERCENT_SCALER))
     }
 
+    /// Create scaled decimal from bps value
+    pub fn from_bps(bps: u64) -> Self {
+        Self(U192::from(bps * BPS_SCALER))
+    }
+
     /// Return raw scaled value if it fits within u128
     #[allow(clippy::wrong_self_convention)]
     pub fn to_scaled_val(&self) -> Result<u128, ProgramError> {
@@ -231,6 +236,14 @@ mod test {
     fn test_from_percent() {
         let left = Decimal::from_percent(20);
         let right = Decimal::from(20u64).try_div(Decimal::from(100u64)).unwrap();
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn test_from_bps() {
+        let left = Decimal::from_bps(2000);
+        let right = Decimal::from_percent(20);
 
         assert_eq!(left, right);
     }

--- a/token-lending/sdk/src/math/decimal.rs
+++ b/token-lending/sdk/src/math/decimal.rs
@@ -26,7 +26,7 @@ construct_uint! {
 }
 
 /// Large decimal values, precise to 18 digits
-#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Decimal(pub U192);
 
 impl Decimal {
@@ -113,6 +113,12 @@ impl fmt::Display for Decimal {
             scaled_val.insert(scaled_val.len() - SCALE, '.');
         }
         f.write_str(&scaled_val)
+    }
+}
+
+impl fmt::Debug for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -37,7 +37,7 @@ pub struct Obligation {
     pub borrows: Vec<ObligationLiquidity>,
     /// Market value of deposits
     pub deposited_value: Decimal,
-    /// Market value of borrows
+    /// Risk-adjusted market value of borrows
     pub borrowed_value: Decimal,
     /// The maximum borrow value at the weighted average loan to value ratio
     pub allowed_borrow_value: Decimal,

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -913,7 +913,7 @@ impl Pack for Reserve {
             1,
             1,
             16,
-            56,
+            RATE_LIMITER_LEN,
             8,
             166
         ];
@@ -1047,7 +1047,7 @@ impl Pack for Reserve {
             1,
             1,
             16,
-            56,
+            RATE_LIMITER_LEN,
             8,
             166
         ];
@@ -1773,5 +1773,21 @@ mod test {
                 test_case.remaining_reserve_capacity,
             ), test_case.result);
         }
+    }
+
+    // test that unpacking a reserve with a borrow weight of 0 fails
+    #[test]
+    fn test_unpack_reserve_with_zero_borrow_weight() {
+        let mut reserve = Reserve {
+            version: PROGRAM_VERSION,
+            ..Reserve::default()
+        };
+        reserve.config.borrow_weight_bps = 0;
+
+        let mut buf = [0u8; Reserve::LEN];
+        Reserve::pack(reserve, &mut buf).unwrap();
+
+        let unpacked_reserve = Reserve::unpack(&buf).unwrap();
+        assert_eq!(unpacked_reserve.config.borrow_weight_bps, 10_000);
     }
 }


### PR DESCRIPTION
Summary: 
Add a borrow weight to the Reserve

before, borrowed value in usd was calculated by
```python
borrowed_value_usd = sum(b.borrow_amount * b.token_price for b in obligation.borrows)
```

now, we do:
```python
borrowed_value_usd = sum(b.borrow_weight * b.borrow_amount * b.token_price for b in obligation.borrows)
```

Borrow weight is _always greater than 1_.

Purpose: If some reserve R is at 100% util, then any liquidator who liquidates an obligation that's collateralized by R will receive cTokens, which is undesirable. With this change, when reserve util is close to or at 100%, Solend plans to increase the borrow weight. This in turn will cause liquidations to happen, and reserve util will eventually decrease.

Affected instructions

- borrow obligation liquidity: strictly more conservative now
- withdraw obligation collateral / withdraw obligation collateral and redeem reserve liquidity: also more conservative
- liquidate obligation collateral and redeem reserve liquidity: the increase in borrow weight can make certain obligations now unhealthy. Also, the increase in borrow weight causes a _bigger_ liquidation.


Testing
- borrow obligation liquidity: a previously valid borrow is now rejected because of the borrow weight change
- withdraw: a previously valid withdraw is now rejected because of the borrow weight change
- liquidate: a previously healthy obligation is now unhealthy when borrow weight is increased, and can be liquidated
