### PR TITLE
Two Prices PR

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1470,7 +1470,9 @@ fn process_borrow_obligation_liquidity(
         return Err(LendingError::InvalidMarketAuthority.into());
     }
 
-    let remaining_borrow_value = obligation.remaining_borrow_value()?;
+    let remaining_borrow_value = obligation
+        .remaining_borrow_value()
+        .unwrap_or_else(|_| Decimal::zero());
     if remaining_borrow_value == Decimal::zero() {
         msg!("Remaining borrow value is zero");
         return Err(LendingError::BorrowTooLarge.into());

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -488,8 +488,15 @@ fn _refresh_reserve<'a>(
         get_price(switchboard_feed_info, pyth_price_info, clock)?;
 
     reserve.liquidity.market_price = market_price;
+
     if let Some(smoothed_market_price) = smoothed_market_price {
         reserve.liquidity.smoothed_market_price = smoothed_market_price;
+    }
+
+    // currently there's no way to support two prices without a pyth oracle. So if a reserve
+    // only supports switchboard, reserve.smoothed_market_price == reserve.market_price
+    if reserve.liquidity.pyth_oracle_pubkey == solend_program::NULL_PUBKEY {
+        reserve.liquidity.smoothed_market_price = market_price;
     }
 
     Reserve::pack(reserve, &mut reserve_info.data.borrow_mut())?;

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -61,6 +61,10 @@ pub mod usdc_mint {
     solana_program::declare_id!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 }
 
+pub mod usdt_mint {
+    solana_program::declare_id!("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB");
+}
+
 pub mod wsol_mint {
     // fake mint, not the real wsol bc i can't mint wsol programmatically
     solana_program::declare_id!("So1m5eppzgokXLBt9Cg8KCMPWhHfTzVaGh26Y415MRG");

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -383,7 +383,7 @@ impl SolendProgramTest {
         .unwrap();
     }
 
-    pub async fn init_switchboard_feed(&mut self, mint: &Pubkey)-> Pubkey {
+    pub async fn init_switchboard_feed(&mut self, mint: &Pubkey) -> Pubkey {
         let switchboard_feed_pubkey = self
             .create_account(
                 std::mem::size_of::<AggregatorAccountData>() + 8,

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -369,6 +369,8 @@ impl SolendProgramTest {
                 price.price,
                 price.conf,
                 price.expo,
+                price.ema_price,
+                price.ema_conf,
             )],
             None,
         )
@@ -599,6 +601,8 @@ pub struct PriceArgs {
     pub price: i64,
     pub conf: u64,
     pub expo: i32,
+    pub ema_price: i64,
+    pub ema_conf: u64,
 }
 
 impl Info<LendingMarket> {
@@ -1297,6 +1301,8 @@ pub async fn setup_world(
             price: 1,
             conf: 0,
             expo: 0,
+            ema_price: 1,
+            ema_conf: 0
         },
     )
     .await;
@@ -1308,6 +1314,8 @@ pub async fn setup_world(
             price: 10,
             conf: 0,
             expo: 0,
+            ema_price: 10,
+            ema_conf: 0
         },
     )
     .await;

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -383,7 +383,7 @@ impl SolendProgramTest {
         .unwrap();
     }
 
-    pub async fn init_switchboard_feed(&mut self, mint: &Pubkey) {
+    pub async fn init_switchboard_feed(&mut self, mint: &Pubkey)-> Pubkey {
         let switchboard_feed_pubkey = self
             .create_account(
                 std::mem::size_of::<AggregatorAccountData>() + 8,
@@ -405,12 +405,13 @@ impl SolendProgramTest {
         let oracle = self.mints.get_mut(mint).unwrap();
         if let Some(ref mut oracle) = oracle {
             oracle.switchboard_feed_pubkey = Some(switchboard_feed_pubkey);
+            switchboard_feed_pubkey
         } else {
             panic!("oracle not initialized");
         }
     }
 
-    pub async fn set_switchboard_price(&mut self, mint: &Pubkey, price: PriceArgs) {
+    pub async fn set_switchboard_price(&mut self, mint: &Pubkey, price: SwitchboardPriceArgs) {
         let oracle = self.mints.get(mint).unwrap().unwrap();
         self.process_transaction(
             &[set_switchboard_price(
@@ -610,6 +611,11 @@ pub struct PriceArgs {
     pub ema_conf: u64,
 }
 
+pub struct SwitchboardPriceArgs {
+    pub price: i64,
+    pub expo: i32,
+}
+
 impl Info<LendingMarket> {
     pub async fn deposit(
         &self,
@@ -651,7 +657,6 @@ impl Info<LendingMarket> {
             .unwrap()
             .unwrap();
         let oracle = oracle.unwrap_or(&default_oracle);
-        println!("{:?}", oracle);
 
         let instructions = [update_reserve_config(
             solend_program::id(),

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -360,7 +360,7 @@ impl SolendProgramTest {
         );
     }
 
-    pub async fn set_price(&mut self, mint: &Pubkey, price: PriceArgs) {
+    pub async fn set_price(&mut self, mint: &Pubkey, price: &PriceArgs) {
         let oracle = self.mints.get(mint).unwrap().unwrap();
         self.process_transaction(
             &[set_price(
@@ -570,7 +570,7 @@ impl User {
 
                 account
             }
-            Some(_) => panic!("Token account already exists!"),
+            Some(t) => t.clone(),
         }
     }
 
@@ -1297,7 +1297,7 @@ pub async fn setup_world(
     test.init_pyth_feed(&usdc_mint::id()).await;
     test.set_price(
         &usdc_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 1,
             conf: 0,
             expo: 0,
@@ -1310,7 +1310,7 @@ pub async fn setup_world(
     test.init_pyth_feed(&wsol_mint::id()).await;
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 10,
             conf: 0,
             expo: 0,
@@ -1481,4 +1481,138 @@ pub async fn scenario_1(
         user,
         obligation,
     )
+}
+
+pub struct ReserveArgs {
+    pub mint: Pubkey,
+    pub config: ReserveConfig,
+    pub liquidity_amount: u64,
+    pub price: PriceArgs,
+}
+
+pub struct ObligationArgs {
+    pub deposits: Vec<(Pubkey, u64)>,
+    pub borrows: Vec<(Pubkey, u64)>,
+}
+
+pub async fn custom_scenario(
+    reserve_args: &[ReserveArgs],
+    obligation_args: &ObligationArgs,
+) -> (
+    SolendProgramTest,
+    Info<LendingMarket>,
+    Vec<Info<Reserve>>,
+    Info<Obligation>,
+    User,
+) {
+    let mut test = SolendProgramTest::start_new().await;
+    let mints_and_liquidity_amounts = reserve_args
+        .iter()
+        .map(|reserve_arg| (&reserve_arg.mint, reserve_arg.liquidity_amount))
+        .collect::<Vec<_>>();
+
+    let lending_market_owner =
+        User::new_with_balances(&mut test, &mints_and_liquidity_amounts).await;
+
+    let lending_market = test
+        .init_lending_market(&lending_market_owner, &Keypair::new())
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(999).await;
+
+    let mut reserves = Vec::new();
+    for reserve_arg in reserve_args {
+        test.init_pyth_feed(&reserve_arg.mint).await;
+
+        test.set_price(&reserve_arg.mint, &reserve_arg.price).await;
+
+        let reserve = test
+            .init_reserve(
+                &lending_market,
+                &lending_market_owner,
+                &reserve_arg.mint,
+                &reserve_arg.config,
+                &Keypair::new(),
+                reserve_arg.liquidity_amount,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let user = User::new_with_balances(
+            &mut test,
+            &[
+                (&reserve_arg.mint, reserve_arg.liquidity_amount),
+                (&reserve.account.collateral.mint_pubkey, 0),
+            ],
+        )
+        .await;
+
+        lending_market
+            .deposit(&mut test, &reserve, &user, reserve_arg.liquidity_amount)
+            .await
+            .unwrap();
+
+        reserves.push(reserve);
+    }
+
+    let deposits_and_balances = obligation_args
+        .deposits
+        .iter()
+        .map(|(mint, amount)| (mint, *amount))
+        .collect::<Vec<_>>();
+
+    let mut obligation_owner = User::new_with_balances(&mut test, &deposits_and_balances).await;
+
+    let obligation = lending_market
+        .init_obligation(&mut test, Keypair::new(), &obligation_owner)
+        .await
+        .unwrap();
+
+    for (mint, amount) in obligation_args.deposits.iter() {
+        let reserve = reserves
+            .iter()
+            .find(|reserve| reserve.account.liquidity.mint_pubkey == *mint)
+            .unwrap();
+
+        obligation_owner
+            .create_token_account(&reserve.account.collateral.mint_pubkey, &mut test)
+            .await;
+
+        lending_market
+            .deposit_reserve_liquidity_and_obligation_collateral(
+                &mut test,
+                reserve,
+                &obligation,
+                &obligation_owner,
+                *amount,
+            )
+            .await
+            .unwrap();
+    }
+
+    for (mint, amount) in obligation_args.borrows.iter() {
+        let reserve = reserves
+            .iter()
+            .find(|reserve| reserve.account.liquidity.mint_pubkey == *mint)
+            .unwrap();
+
+        obligation_owner.create_token_account(mint, &mut test).await;
+        let fee_receiver = User::new_with_balances(&mut test, &[(mint, 0)]).await;
+
+        lending_market
+            .borrow_obligation_liquidity(
+                &mut test,
+                reserve,
+                &obligation,
+                &obligation_owner,
+                &fee_receiver.get_account(mint).unwrap(),
+                *amount,
+            )
+            .await
+            .unwrap();
+    }
+
+    (test, lending_market, reserves, obligation, obligation_owner)
 }

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1302,7 +1302,7 @@ pub async fn setup_world(
             conf: 0,
             expo: 0,
             ema_price: 1,
-            ema_conf: 0
+            ema_conf: 0,
         },
     )
     .await;
@@ -1315,7 +1315,7 @@ pub async fn setup_world(
             conf: 0,
             expo: 0,
             ema_price: 10,
-            ema_conf: 0
+            ema_conf: 0,
         },
     )
     .await;

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -45,6 +45,7 @@ async fn test_success() {
             borrows: Vec::new(),
             deposited_value: Decimal::zero(),
             borrowed_value: Decimal::zero(),
+            borrowed_value_upper_bound: Decimal::zero(),
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero()
         }

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -169,6 +169,7 @@ async fn test_success() {
                 cumulative_borrow_rate_wads: Decimal::one(),
                 accumulated_protocol_fees_wads: Decimal::zero(),
                 market_price: Decimal::from(10u64),
+                smoothed_market_price: Decimal::from(10u64),
             },
             collateral: ReserveCollateral {
                 mint_pubkey: reserve_collateral_mint_pubkey,

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -63,7 +63,7 @@ async fn test_success_new() {
     // obligation gets liquidated if 100k * 0.55 = 10 SOL * sol_price => sol_price = 5.5k
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 5500,
             conf: 0,
             expo: 0,
@@ -289,7 +289,7 @@ async fn test_success_insufficient_liquidity() {
     // obligation gets liquidated if 100k * 0.55 = 10 SOL * sol_price => sol_price == 5.5k
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 5500,
             conf: 0,
             expo: 0,

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -213,6 +213,7 @@ async fn test_success_new() {
             .to_vec(),
             deposited_value: Decimal::from(100_000u64),
             borrowed_value: Decimal::from(55_000u64),
+            borrowed_value_upper_bound: Decimal::from(55_000u64),
             allowed_borrow_value: Decimal::from(50_000u64),
             unhealthy_borrow_value: Decimal::from(55_000u64),
             ..obligation.account

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -67,6 +67,8 @@ async fn test_success_new() {
             price: 5500,
             conf: 0,
             expo: 0,
+            ema_price: 5500,
+            ema_conf: 0,
         },
     )
     .await;
@@ -179,6 +181,7 @@ async fn test_success_new() {
                     .try_sub(Decimal::from(expected_borrow_repaid * LAMPORTS_TO_SOL))
                     .unwrap(),
                 market_price: Decimal::from(5500u64),
+                smoothed_market_price: Decimal::from(5500u64),
                 ..wsol_reserve.account.liquidity
             },
             ..wsol_reserve.account
@@ -289,6 +292,8 @@ async fn test_success_insufficient_liquidity() {
             price: 5500,
             conf: 0,
             expo: 0,
+            ema_price: 5500,
+            ema_conf: 0,
         },
     )
     .await;

--- a/token-lending/program/tests/redeem_fees.rs
+++ b/token-lending/program/tests/redeem_fees.rs
@@ -34,7 +34,7 @@ async fn test_success() {
 
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 10,
             expo: 0,
             conf: 0,

--- a/token-lending/program/tests/redeem_fees.rs
+++ b/token-lending/program/tests/redeem_fees.rs
@@ -38,6 +38,8 @@ async fn test_success() {
             price: 10,
             expo: 0,
             conf: 0,
+            ema_price: 10,
+            ema_conf: 0,
         },
     )
     .await;

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -138,7 +138,7 @@ async fn test_success() {
 
     test.set_price(
         &usdc_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 10,
             conf: 1,
             expo: -1,
@@ -150,7 +150,7 @@ async fn test_success() {
 
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 10,
             conf: 1,
             expo: 0,
@@ -258,12 +258,14 @@ async fn test_success() {
                 .try_div(Decimal::from(LAMPORTS_PER_SOL))
                 .unwrap(),
 
+            // uses max(10, 11) = 11 for sol price
             borrowed_value_upper_bound: new_borrowed_amount_wads
                 .try_mul(Decimal::from(11u64))
                 .unwrap()
                 .try_div(Decimal::from(LAMPORTS_PER_SOL))
                 .unwrap(),
 
+            // uses min(1, 0.9) for usdc price
             allowed_borrow_value: Decimal::from(100_000u64)
                 .try_mul(Decimal::from_percent(
                     usdc_reserve.account.config.loan_to_value_ratio

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -239,6 +239,7 @@ async fn test_success() {
             }]
             .to_vec(),
             borrowed_value: new_borrow_value,
+            borrowed_value_upper_bound: new_borrow_value,
             // uses ema price to calculate allowed borrow value
             allowed_borrow_value: Decimal::from(100_000u64)
                 .try_mul(Decimal::from_percent(

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -10,8 +10,8 @@ use helpers::*;
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::*;
 use solana_sdk::signature::Keypair;
+use solend_program::state::SLOTS_PER_YEAR;
 use solend_program::state::{LastUpdate, ObligationLiquidity, ReserveFees, ReserveLiquidity};
-use solend_program::state::{SLOTS_PER_YEAR};
 
 use solend_program::{
     math::{Decimal, TryAdd, TryDiv, TryMul},

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -148,8 +148,21 @@ async fn test_success() {
     // should be maxed out at 30%
     let borrow_rate = wsol_reserve.account.current_borrow_rate().unwrap();
 
+    test.set_price(
+        &wsol_mint::id(),
+        PriceArgs {
+            price: 20,
+            conf: 1,
+            expo: 1,
+            ema_price: 15,
+            ema_conf: 1,
+        },
+    )
+    .await;
+
     test.advance_clock_by_slots(1).await;
     let balance_checker = BalanceChecker::start(&mut test, &[&wsol_reserve]).await;
+
 
     lending_market
         .refresh_reserve(&mut test, &wsol_reserve)
@@ -187,6 +200,8 @@ async fn test_success() {
                 borrowed_amount_wads: compound_borrow,
                 cumulative_borrow_rate_wads: compound_rate.into(),
                 accumulated_protocol_fees_wads: delta_accumulated_protocol_fees,
+                market_price: Decimal::from(200u64),
+                smoothed_market_price: Decimal::from(150u64),
                 ..wsol_reserve.account.liquidity
             },
             ..wsol_reserve.account
@@ -229,6 +244,8 @@ async fn test_success_pyth_price_stale_switchboard_valid() {
             price: 10,
             expo: 0,
             conf: 0,
+            ema_price: 10,
+            ema_conf: 0,
         },
     )
     .await;

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -163,7 +163,6 @@ async fn test_success() {
     test.advance_clock_by_slots(1).await;
     let balance_checker = BalanceChecker::start(&mut test, &[&wsol_reserve]).await;
 
-
     lending_market
         .refresh_reserve(&mut test, &wsol_reserve)
         .await

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -150,7 +150,7 @@ async fn test_success() {
 
     test.set_price(
         &wsol_mint::id(),
-        PriceArgs {
+        &PriceArgs {
             price: 20,
             conf: 1,
             expo: 1,

--- a/token-lending/program/tests/two_prices.rs
+++ b/token-lending/program/tests/two_prices.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::solend_program_test::custom_scenario;
-use crate::solend_program_test::setup_world;
+use crate::solend_program_test::find_reserve;
+use crate::solend_program_test::User;
+
 use crate::solend_program_test::BalanceChecker;
 use crate::solend_program_test::ObligationArgs;
 use crate::solend_program_test::PriceArgs;
@@ -11,18 +13,15 @@ use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
 use solend_program::error::LendingError;
+
 use solend_program::state::ReserveConfig;
 use solend_program::NULL_PUBKEY;
 use solend_sdk::state::ReserveFees;
 mod helpers;
 
-use crate::solend_program_test::scenario_1;
-use crate::solend_program_test::User;
 use helpers::*;
 use solana_program_test::*;
-use solana_sdk::signature::Keypair;
-use solend_program::math::Decimal;
-use solend_program::state::Obligation;
+
 use std::collections::HashSet;
 
 /// the two prices feature affects a bunch of instructions. All of those instructions are tested
@@ -37,7 +36,7 @@ async fn test_borrow() {
                 config: test_reserve_config(),
                 liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
                 price: PriceArgs {
-                    price: 9,
+                    price: 10,
                     conf: 0,
                     expo: -1,
                     ema_price: 10,
@@ -50,11 +49,13 @@ async fn test_borrow() {
                     loan_to_value_ratio: 50,
                     liquidation_threshold: 55,
                     fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 100 * LAMPORTS_PER_SOL,
                 price: PriceArgs {
-                    price: 9,
+                    price: 10,
                     conf: 0,
                     expo: 0,
                     ema_price: 10,
@@ -63,22 +64,13 @@ async fn test_borrow() {
             },
         ],
         &ObligationArgs {
-            deposits: vec![],
-            borrows: vec![],
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
         },
     )
     .await;
-    // let (mut test, lending_market, _, wsol_reserve, user, obligation) = scenario_1(
-    //     &test_reserve_config(),
-    //     &ReserveConfig {
-    //         loan_to_value_ratio: 50,
-    //         liquidation_threshold: 55,
-    //         fees: ReserveFees::default(),
-    //         ..test_reserve_config()
-    //     },
-    // )
-    // .await;
 
+    // update prices
     test.set_price(
         &usdc_mint::id(),
         &PriceArgs {
@@ -86,51 +78,408 @@ async fn test_borrow() {
             conf: 0,
             expo: -1,
             ema_price: 10,
-            ema_conf: 1,
+            ema_conf: 0,
         },
     )
     .await;
 
-    // test.set_price(
-    //     &wsol_mint::id(),
-    //     &PriceArgs {
-    //         price: 10,
-    //         conf: 0,
-    //         expo: 0,
-    //         ema_price: 12,
-    //         ema_conf: 1,
-    //     },
-    // )
-    // .await;
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 10,
+            conf: 0,
+            expo: 0,
+            ema_price: 20,
+            ema_conf: 0,
+        },
+    )
+    .await;
 
     test.advance_clock_by_slots(1).await;
 
-    // lending_market
-    //     .refresh_obligation(&mut test, &obligation)
-    //     .await
-    //     .unwrap();
-    // let obligation = test.load_account(obligation.pubkey).await;
-    // println!("obligation before: {:#?}", obligation);
+    let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;
 
-    // let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;
+    // obligation currently has 100 USDC deposited and 1 sol borrowed
+    // if we try to borrow the max amount, how much SOL should we receive?
+    // allowed borrow value = 100 * min(1, 0.9) * 0.5 = $45
+    // borrow value upper bound: 1 * max(10, 20) = $20
+    // max SOL that can be borrowed is: ($45 - $20) / $20 = 1.25 SOL
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            &find_reserve(&reserves, &wsol_mint::id()).unwrap(),
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
 
-    // // obligation currently has 100k USDC deposited, 10 SOL borrowed.
-    // // if we try to borrow the max amount, how much SOL should we receive?
-    // // allowed borrow value = 100k * 0.9 * 0.5 = $45k
-    // // borrow value upper bound = 10 * 20 = $200
-    // // max SOL that can be borrowed is: ($45k - $200) / 20 = 2240 SOL
-    // lending_market
-    //     .borrow_obligation_liquidity(
-    //         &mut test,
-    //         &wsol_reserve,
-    //         &obligation,
-    //         &user,
-    //         &NULL_PUBKEY,
-    //         u64::MAX,
-    //     )
-    //     .await
-    //     .unwrap();
+    let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+    let expected_balance_changes = HashSet::from([TokenBalanceChange {
+        token_account: user.get_account(&wsol_mint::id()).unwrap(),
+        mint: wsol_mint::id(),
+        diff: (LAMPORTS_PER_SOL * 125 / 100) as i128,
+    }]);
 
-    // let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
-    // println!("{:#?}", balance_changes);
+    assert_eq!(balance_changes, expected_balance_changes);
+
+    test.advance_clock_by_slots(1).await;
+
+    // shouldn't be able to borrow any more
+    let err = lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            &find_reserve(&reserves, &wsol_mint::id()).unwrap(),
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            u64::MAX,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            3,
+            InstructionError::Custom(LendingError::BorrowTooLarge as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw() {
+    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: -1,
+                    ema_price: 10,
+                    ema_conf: 1,
+                },
+            },
+            ReserveArgs {
+                mint: usdt_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: -1,
+                    ema_price: 10,
+                    ema_conf: 1,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 50,
+                    liquidation_threshold: 55,
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    fees: ReserveFees::default(),
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![
+                (usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
+                (usdt_mint::id(), 20 * FRACTIONAL_TO_USDC),
+            ],
+            borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
+        },
+    )
+    .await;
+
+    // update prices
+    test.set_price(
+        &usdc_mint::id(),
+        &PriceArgs {
+            price: 100, // massive price increase
+            conf: 0,
+            expo: 0,
+            ema_price: 1,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 10, // big price decrease
+            conf: 0,
+            expo: 0,
+            ema_price: 20,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;
+
+    lending_market
+        .withdraw_obligation_collateral_and_redeem_reserve_collateral(
+            &mut test,
+            &find_reserve(&reserves, &usdc_mint::id()).unwrap(),
+            &obligation,
+            &user,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+    // how much usdc should we able to withdraw?
+    // current allowed borrow value: 100 * min(100, 1) * 0.5 + 20 * min(1, 1) * 0.5 = $60
+    // borrow value upper bound = 1 SOL * max($20, $10) = $20
+    // max withdraw value = ($60 - $20) / 0.5 = $80
+    // max withdraw liquidity amount = $80 / min(100, 1) = *80 USDC*
+    // note that if we didn't have this two prices feature, you could withdraw all of the USDC
+    // cUSDC/USDC exchange rate = 1 => max withdraw is 80 cUSDC
+    //
+    // reconciliation:
+    // after withdraw, we are left with 20 USDC, 20 USDT
+    // allowed borrow value is now 20 * min(100, 1) * 0.5 + 20 * min(1, 1) * 0.5 = $20
+    // borrow value upper bound = $20
+    // we have successfully borrowed the max amount
+    let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+    let expected_balance_changes = HashSet::from([TokenBalanceChange {
+        token_account: user.get_account(&usdc_mint::id()).unwrap(),
+        mint: usdc_mint::id(),
+        diff: (80 * FRACTIONAL_TO_USDC) as i128,
+    }]);
+
+    assert_eq!(balance_changes, expected_balance_changes);
+
+    // we shouldn't be able to withdraw anything else
+    for mint in [usdc_mint::id(), usdt_mint::id()] {
+        let err = lending_market
+            .withdraw_obligation_collateral_and_redeem_reserve_collateral(
+                &mut test,
+                &find_reserve(&reserves, &mint).unwrap(),
+                &obligation,
+                &user,
+                u64::MAX,
+            )
+            .await
+            .unwrap_err()
+            .unwrap();
+
+        assert_eq!(
+            err,
+            TransactionError::InstructionError(
+                4,
+                InstructionError::Custom(LendingError::WithdrawTooLarge as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_liquidation_doesnt_use_smoothed_price() {
+    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 50,
+                    liquidation_threshold: 55,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
+        },
+    )
+    .await;
+
+    // set ema price to 100
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 10,
+            conf: 0,
+            expo: 0,
+            ema_price: 100,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    // this should fail bc the obligation is still healthy wrt the current non-ema market prices
+    let err = lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            &find_reserve(&reserves, &wsol_mint::id()).unwrap(),
+            &find_reserve(&reserves, &usdc_mint::id()).unwrap(),
+            &obligation,
+            &user,
+            u64::MAX,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            3,
+            InstructionError::Custom(LendingError::ObligationHealthy as u32)
+        )
+    );
+
+    test.set_price(
+        &usdc_mint::id(),
+        &PriceArgs {
+            price: 1,
+            conf: 0,
+            expo: 0,
+            ema_price: 0,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    // this should fail bc the obligation is still healthy wrt the current non-ema market prices
+    let err = lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            &find_reserve(&reserves, &wsol_mint::id()).unwrap(),
+            &find_reserve(&reserves, &usdc_mint::id()).unwrap(),
+            &obligation,
+            &user,
+            u64::MAX,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            3,
+            InstructionError::Custom(LendingError::ObligationHealthy as u32)
+        )
+    );
+
+    // now set the spot prices. this time, the liquidation should actually work
+    test.set_price(
+        &usdc_mint::id(),
+        &PriceArgs {
+            price: 1,
+            conf: 0,
+            expo: 0,
+            ema_price: 10,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 100,
+            conf: 0,
+            expo: 0,
+            ema_price: 10,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    let usdc_reserve = find_reserve(&reserves, &usdc_mint::id()).unwrap();
+    let wsol_reserve = find_reserve(&reserves, &wsol_mint::id()).unwrap();
+
+    let liquidator = User::new_with_balances(
+        &mut test,
+        &[
+            (&usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
+            (&usdc_reserve.account.collateral.mint_pubkey, 0),
+            (&wsol_mint::id(), 100 * LAMPORTS_PER_SOL),
+            (&wsol_reserve.account.collateral.mint_pubkey, 0),
+        ],
+    )
+    .await;
+
+    let balance_checker = BalanceChecker::start(&mut test, &[&liquidator]).await;
+
+    lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            &find_reserve(&reserves, &wsol_mint::id()).unwrap(),
+            &find_reserve(&reserves, &usdc_mint::id()).unwrap(),
+            &obligation,
+            &liquidator,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+    let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+    // make sure the liquidation amounts are also wrt spot prices
+    let expected_balances_changes = HashSet::from([
+        TokenBalanceChange {
+            token_account: liquidator.get_account(&usdc_mint::id()).unwrap(),
+            mint: usdc_mint::id(),
+            diff: (20 * FRACTIONAL_TO_USDC * 105 / 100) as i128 - 1,
+        },
+        TokenBalanceChange {
+            token_account: liquidator.get_account(&wsol_mint::id()).unwrap(),
+            mint: wsol_mint::id(),
+            diff: -((LAMPORTS_PER_SOL / 5) as i128),
+        },
+    ]);
+
+    assert_eq!(balance_changes, expected_balances_changes);
 }

--- a/token-lending/program/tests/two_prices.rs
+++ b/token-lending/program/tests/two_prices.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "test-bpf")]
+
+use crate::solend_program_test::custom_scenario;
+use crate::solend_program_test::setup_world;
+use crate::solend_program_test::BalanceChecker;
+use crate::solend_program_test::ObligationArgs;
+use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
+use crate::solend_program_test::TokenBalanceChange;
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+use solend_program::state::ReserveConfig;
+use solend_program::NULL_PUBKEY;
+use solend_sdk::state::ReserveFees;
+mod helpers;
+
+use crate::solend_program_test::scenario_1;
+use crate::solend_program_test::User;
+use helpers::*;
+use solana_program_test::*;
+use solana_sdk::signature::Keypair;
+use solend_program::math::Decimal;
+use solend_program::state::Obligation;
+use std::collections::HashSet;
+
+/// the two prices feature affects a bunch of instructions. All of those instructions are tested
+/// here for correctness.
+
+#[tokio::test]
+async fn test_borrow() {
+    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 9,
+                    conf: 0,
+                    expo: -1,
+                    ema_price: 10,
+                    ema_conf: 1,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 50,
+                    liquidation_threshold: 55,
+                    fees: ReserveFees::default(),
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 9,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![],
+            borrows: vec![],
+        },
+    )
+    .await;
+    // let (mut test, lending_market, _, wsol_reserve, user, obligation) = scenario_1(
+    //     &test_reserve_config(),
+    //     &ReserveConfig {
+    //         loan_to_value_ratio: 50,
+    //         liquidation_threshold: 55,
+    //         fees: ReserveFees::default(),
+    //         ..test_reserve_config()
+    //     },
+    // )
+    // .await;
+
+    test.set_price(
+        &usdc_mint::id(),
+        &PriceArgs {
+            price: 9,
+            conf: 0,
+            expo: -1,
+            ema_price: 10,
+            ema_conf: 1,
+        },
+    )
+    .await;
+
+    // test.set_price(
+    //     &wsol_mint::id(),
+    //     &PriceArgs {
+    //         price: 10,
+    //         conf: 0,
+    //         expo: 0,
+    //         ema_price: 12,
+    //         ema_conf: 1,
+    //     },
+    // )
+    // .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    // lending_market
+    //     .refresh_obligation(&mut test, &obligation)
+    //     .await
+    //     .unwrap();
+    // let obligation = test.load_account(obligation.pubkey).await;
+    // println!("obligation before: {:#?}", obligation);
+
+    // let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;
+
+    // // obligation currently has 100k USDC deposited, 10 SOL borrowed.
+    // // if we try to borrow the max amount, how much SOL should we receive?
+    // // allowed borrow value = 100k * 0.9 * 0.5 = $45k
+    // // borrow value upper bound = 10 * 20 = $200
+    // // max SOL that can be borrowed is: ($45k - $200) / 20 = 2240 SOL
+    // lending_market
+    //     .borrow_obligation_liquidity(
+    //         &mut test,
+    //         &wsol_reserve,
+    //         &obligation,
+    //         &user,
+    //         &NULL_PUBKEY,
+    //         u64::MAX,
+    //     )
+    //     .await
+    //     .unwrap();
+
+    // let (balance_changes, _) = balance_checker.find_balance_changes(&mut test).await;
+    // println!("{:#?}", balance_changes);
+}

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -2,14 +2,14 @@
 
 mod helpers;
 
-use crate::solend_program_test::PriceArgs;
+
 use crate::solend_program_test::scenario_1;
 use helpers::solend_program_test::{BalanceChecker, TokenBalanceChange};
 use helpers::*;
 
 use solana_program_test::*;
-use solana_sdk::{instruction::InstructionError, transaction::TransactionError};
-use solend_program::error::LendingError;
+
+
 use solend_program::state::{LastUpdate, Obligation, ObligationCollateral, Reserve};
 use std::collections::HashSet;
 use std::u64;
@@ -130,110 +130,3 @@ async fn test_success_withdraw_max() {
         }
     );
 }
-
-#[tokio::test]
-async fn test_fail_withdraw_too_much() {
-    let (mut test, lending_market, usdc_reserve, _wsol_reserve, user, obligation) =
-        scenario_1(&test_reserve_config(), &test_reserve_config()).await;
-
-    let res = lending_market
-        .withdraw_obligation_collateral(
-            &mut test,
-            &usdc_reserve,
-            &obligation,
-            &user,
-            100_000_000_000 - 200_000_000 + 1,
-        )
-        .await
-        .err()
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(
-        res,
-        TransactionError::InstructionError(
-            3,
-            InstructionError::Custom(LendingError::WithdrawTooLarge as u32)
-        )
-    );
-}
-
-// #[tokio::test]
-// async fn test_success_withdraw_max_ema() {
-//     let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation) =
-//         scenario_1(&test_reserve_config(), &test_reserve_config()).await;
-
-//     test.set_price(
-//         &usdc_mint::id(),
-//         PriceArgs {
-//             price: 10,
-//             conf: 1,
-//             expo: -1,
-//             ema_price: 5,
-//             ema_conf: 1,
-//         },
-//     )
-//     .await;
-
-//     let usdc_reserve = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
-
-//     test.advance_clock_by_slots(1).await;
-
-//     let balance_checker =
-//         BalanceChecker::start(&mut test, &[&usdc_reserve, &user, &wsol_reserve]).await;
-
-//     lending_market
-//         .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
-//         .await
-//         .unwrap();
-
-//     // we are borrowing 10 SOL @ $10 with an ltv of 0.5, so the debt has to be collateralized by
-//     // exactly 200cUSDC.
-//     let sol_borrowed = obligation.account.borrows[0]
-//         .borrowed_amount_wads
-//         .try_ceil_u64()
-//         .unwrap()
-//         / LAMPORTS_TO_SOL;
-//     let expected_remaining_collateral = sol_borrowed * 10 * 2 * FRACTIONAL_TO_USDC;
-
-//     let (balance_changes, mint_supply_changes) =
-//         balance_checker.find_balance_changes(&mut test).await;
-//     println!("{:#?}", balance_changes);
-//     // let expected_balance_changes = HashSet::from([
-//     //     TokenBalanceChange {
-//     //         token_account: user
-//     //             .get_account(&usdc_reserve.account.collateral.mint_pubkey)
-//     //             .unwrap(),
-//     //         mint: usdc_reserve.account.collateral.mint_pubkey,
-//     //         diff: (100_000 * FRACTIONAL_TO_USDC - expected_remaining_collateral) as i128,
-//     //     },
-//     //     TokenBalanceChange {
-//     //         token_account: usdc_reserve.account.collateral.supply_pubkey,
-//     //         mint: usdc_reserve.account.collateral.mint_pubkey,
-//     //         diff: -((100_000_000_000 - expected_remaining_collateral) as i128),
-//     //     },
-//     // ]);
-//     // assert_eq!(balance_changes, expected_balance_changes);
-//     // assert_eq!(mint_supply_changes, HashSet::new());
-
-//     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
-//     assert_eq!(usdc_reserve_post.account, usdc_reserve.account);
-
-//     let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
-//     assert_eq!(
-//         obligation_post.account,
-//         Obligation {
-//             last_update: LastUpdate {
-//                 slot: 1000,
-//                 stale: true
-//             },
-//             deposits: [ObligationCollateral {
-//                 deposit_reserve: usdc_reserve.pubkey,
-//                 deposited_amount: expected_remaining_collateral,
-//                 ..obligation.account.deposits[0]
-//             }]
-//             .to_vec(),
-//             ..obligation.account
-//         }
-//     );
-// }

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -158,82 +158,82 @@ async fn test_fail_withdraw_too_much() {
     );
 }
 
-#[tokio::test]
-async fn test_success_withdraw_max_ema() {
-    let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation) =
-        scenario_1(&test_reserve_config(), &test_reserve_config()).await;
+// #[tokio::test]
+// async fn test_success_withdraw_max_ema() {
+//     let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation) =
+//         scenario_1(&test_reserve_config(), &test_reserve_config()).await;
 
-    test.set_price(
-        &usdc_mint::id(),
-        PriceArgs {
-            price: 10,
-            conf: 1,
-            expo: -1,
-            ema_price: 5,
-            ema_conf: 1,
-        },
-    )
-    .await;
+//     test.set_price(
+//         &usdc_mint::id(),
+//         PriceArgs {
+//             price: 10,
+//             conf: 1,
+//             expo: -1,
+//             ema_price: 5,
+//             ema_conf: 1,
+//         },
+//     )
+//     .await;
 
-    let usdc_reserve = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+//     let usdc_reserve = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
 
-    test.advance_clock_by_slots(1).await;
+//     test.advance_clock_by_slots(1).await;
 
-    let balance_checker =
-        BalanceChecker::start(&mut test, &[&usdc_reserve, &user, &wsol_reserve]).await;
+//     let balance_checker =
+//         BalanceChecker::start(&mut test, &[&usdc_reserve, &user, &wsol_reserve]).await;
 
-    lending_market
-        .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
-        .await
-        .unwrap();
+//     lending_market
+//         .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
+//         .await
+//         .unwrap();
 
-    // we are borrowing 10 SOL @ $10 with an ltv of 0.5, so the debt has to be collateralized by
-    // exactly 200cUSDC.
-    let sol_borrowed = obligation.account.borrows[0]
-        .borrowed_amount_wads
-        .try_ceil_u64()
-        .unwrap()
-        / LAMPORTS_TO_SOL;
-    let expected_remaining_collateral = sol_borrowed * 10 * 2 * FRACTIONAL_TO_USDC;
+//     // we are borrowing 10 SOL @ $10 with an ltv of 0.5, so the debt has to be collateralized by
+//     // exactly 200cUSDC.
+//     let sol_borrowed = obligation.account.borrows[0]
+//         .borrowed_amount_wads
+//         .try_ceil_u64()
+//         .unwrap()
+//         / LAMPORTS_TO_SOL;
+//     let expected_remaining_collateral = sol_borrowed * 10 * 2 * FRACTIONAL_TO_USDC;
 
-    let (balance_changes, mint_supply_changes) =
-        balance_checker.find_balance_changes(&mut test).await;
-    println!("{:#?}", balance_changes);
-    // let expected_balance_changes = HashSet::from([
-    //     TokenBalanceChange {
-    //         token_account: user
-    //             .get_account(&usdc_reserve.account.collateral.mint_pubkey)
-    //             .unwrap(),
-    //         mint: usdc_reserve.account.collateral.mint_pubkey,
-    //         diff: (100_000 * FRACTIONAL_TO_USDC - expected_remaining_collateral) as i128,
-    //     },
-    //     TokenBalanceChange {
-    //         token_account: usdc_reserve.account.collateral.supply_pubkey,
-    //         mint: usdc_reserve.account.collateral.mint_pubkey,
-    //         diff: -((100_000_000_000 - expected_remaining_collateral) as i128),
-    //     },
-    // ]);
-    // assert_eq!(balance_changes, expected_balance_changes);
-    // assert_eq!(mint_supply_changes, HashSet::new());
+//     let (balance_changes, mint_supply_changes) =
+//         balance_checker.find_balance_changes(&mut test).await;
+//     println!("{:#?}", balance_changes);
+//     // let expected_balance_changes = HashSet::from([
+//     //     TokenBalanceChange {
+//     //         token_account: user
+//     //             .get_account(&usdc_reserve.account.collateral.mint_pubkey)
+//     //             .unwrap(),
+//     //         mint: usdc_reserve.account.collateral.mint_pubkey,
+//     //         diff: (100_000 * FRACTIONAL_TO_USDC - expected_remaining_collateral) as i128,
+//     //     },
+//     //     TokenBalanceChange {
+//     //         token_account: usdc_reserve.account.collateral.supply_pubkey,
+//     //         mint: usdc_reserve.account.collateral.mint_pubkey,
+//     //         diff: -((100_000_000_000 - expected_remaining_collateral) as i128),
+//     //     },
+//     // ]);
+//     // assert_eq!(balance_changes, expected_balance_changes);
+//     // assert_eq!(mint_supply_changes, HashSet::new());
 
-    let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
-    assert_eq!(usdc_reserve_post.account, usdc_reserve.account);
+//     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+//     assert_eq!(usdc_reserve_post.account, usdc_reserve.account);
 
-    let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
-    assert_eq!(
-        obligation_post.account,
-        Obligation {
-            last_update: LastUpdate {
-                slot: 1000,
-                stale: true
-            },
-            deposits: [ObligationCollateral {
-                deposit_reserve: usdc_reserve.pubkey,
-                deposited_amount: expected_remaining_collateral,
-                ..obligation.account.deposits[0]
-            }]
-            .to_vec(),
-            ..obligation.account
-        }
-    );
-}
+//     let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+//     assert_eq!(
+//         obligation_post.account,
+//         Obligation {
+//             last_update: LastUpdate {
+//                 slot: 1000,
+//                 stale: true
+//             },
+//             deposits: [ObligationCollateral {
+//                 deposit_reserve: usdc_reserve.pubkey,
+//                 deposited_amount: expected_remaining_collateral,
+//                 ..obligation.account.deposits[0]
+//             }]
+//             .to_vec(),
+//             ..obligation.account
+//         }
+//     );
+// }

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -2,6 +2,7 @@
 
 mod helpers;
 
+use crate::solend_program_test::PriceArgs;
 use crate::solend_program_test::scenario_1;
 use helpers::solend_program_test::{BalanceChecker, TokenBalanceChange};
 use helpers::*;
@@ -154,5 +155,85 @@ async fn test_fail_withdraw_too_much() {
             3,
             InstructionError::Custom(LendingError::WithdrawTooLarge as u32)
         )
+    );
+}
+
+#[tokio::test]
+async fn test_success_withdraw_max_ema() {
+    let (mut test, lending_market, usdc_reserve, wsol_reserve, user, obligation) =
+        scenario_1(&test_reserve_config(), &test_reserve_config()).await;
+
+    test.set_price(
+        &usdc_mint::id(),
+        PriceArgs {
+            price: 10,
+            conf: 1,
+            expo: -1,
+            ema_price: 5,
+            ema_conf: 1,
+        },
+    )
+    .await;
+
+    let usdc_reserve = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+
+    test.advance_clock_by_slots(1).await;
+
+    let balance_checker =
+        BalanceChecker::start(&mut test, &[&usdc_reserve, &user, &wsol_reserve]).await;
+
+    lending_market
+        .withdraw_obligation_collateral(&mut test, &usdc_reserve, &obligation, &user, u64::MAX)
+        .await
+        .unwrap();
+
+    // we are borrowing 10 SOL @ $10 with an ltv of 0.5, so the debt has to be collateralized by
+    // exactly 200cUSDC.
+    let sol_borrowed = obligation.account.borrows[0]
+        .borrowed_amount_wads
+        .try_ceil_u64()
+        .unwrap()
+        / LAMPORTS_TO_SOL;
+    let expected_remaining_collateral = sol_borrowed * 10 * 2 * FRACTIONAL_TO_USDC;
+
+    let (balance_changes, mint_supply_changes) =
+        balance_checker.find_balance_changes(&mut test).await;
+    println!("{:#?}", balance_changes);
+    // let expected_balance_changes = HashSet::from([
+    //     TokenBalanceChange {
+    //         token_account: user
+    //             .get_account(&usdc_reserve.account.collateral.mint_pubkey)
+    //             .unwrap(),
+    //         mint: usdc_reserve.account.collateral.mint_pubkey,
+    //         diff: (100_000 * FRACTIONAL_TO_USDC - expected_remaining_collateral) as i128,
+    //     },
+    //     TokenBalanceChange {
+    //         token_account: usdc_reserve.account.collateral.supply_pubkey,
+    //         mint: usdc_reserve.account.collateral.mint_pubkey,
+    //         diff: -((100_000_000_000 - expected_remaining_collateral) as i128),
+    //     },
+    // ]);
+    // assert_eq!(balance_changes, expected_balance_changes);
+    // assert_eq!(mint_supply_changes, HashSet::new());
+
+    let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+    assert_eq!(usdc_reserve_post.account, usdc_reserve.account);
+
+    let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+    assert_eq!(
+        obligation_post.account,
+        Obligation {
+            last_update: LastUpdate {
+                slot: 1000,
+                stale: true
+            },
+            deposits: [ObligationCollateral {
+                deposit_reserve: usdc_reserve.pubkey,
+                deposited_amount: expected_remaining_collateral,
+                ..obligation.account.deposits[0]
+            }]
+            .to_vec(),
+            ..obligation.account
+        }
     );
 }

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -2,13 +2,11 @@
 
 mod helpers;
 
-
 use crate::solend_program_test::scenario_1;
 use helpers::solend_program_test::{BalanceChecker, TokenBalanceChange};
 use helpers::*;
 
 use solana_program_test::*;
-
 
 use solend_program::state::{LastUpdate, Obligation, ObligationCollateral, Reserve};
 use std::collections::HashSet;

--- a/token-lending/sdk/src/oracles.rs
+++ b/token-lending/sdk/src/oracles.rs
@@ -4,7 +4,8 @@ use crate::{
     error::LendingError,
     math::{Decimal, TryDiv, TryMul},
 };
-use pyth_sdk_solana;
+use pyth_sdk_solana::Price;
+// use pyth_sdk_solana;
 use solana_program::{
     account_info::AccountInfo, msg, program_error::ProgramError, sysvar::clock::Clock,
 };
@@ -13,7 +14,7 @@ use std::{convert::TryInto, result::Result};
 pub fn get_pyth_price(
     pyth_price_info: &AccountInfo,
     clock: &Clock,
-) -> Result<Decimal, ProgramError> {
+) -> Result<(Decimal, Decimal), ProgramError> {
     const PYTH_CONFIDENCE_RATIO: u64 = 10;
     const STALE_AFTER_SLOTS_ELAPSED: u64 = 240; // roughly 2 min
 
@@ -50,7 +51,25 @@ pub fn get_pyth_price(
         return Err(LendingError::InvalidOracleConfig.into());
     }
 
-    let market_price = if pyth_price.expo >= 0 {
+    let market_price = pyth_price_to_decimal(&pyth_price);
+    let ema_price = {
+        let price_feed = price_account.to_price_feed(pyth_price_info.key);
+        // this can be unchecked bc the ema price is only used to _limit_ borrows and withdraws.
+        // ie staleness doesn't _really_ matter for this field.
+        let ema_price = price_feed.get_ema_price_unchecked();
+        pyth_price_to_decimal(&ema_price)?
+    };
+
+    Ok((market_price?, ema_price))
+}
+
+fn pyth_price_to_decimal(pyth_price: &Price) -> Result<Decimal, ProgramError> {
+    let price: u64 = pyth_price.price.try_into().map_err(|_| {
+        msg!("Oracle price cannot be negative");
+        LendingError::InvalidOracleConfig
+    })?;
+
+    if pyth_price.expo >= 0 {
         let exponent = pyth_price
             .expo
             .try_into()
@@ -58,7 +77,7 @@ pub fn get_pyth_price(
         let zeros = 10u64
             .checked_pow(exponent)
             .ok_or(LendingError::MathOverflow)?;
-        Decimal::from(price).try_mul(zeros)?
+        Decimal::from(price).try_mul(zeros)
     } else {
         let exponent = pyth_price
             .expo
@@ -69,10 +88,8 @@ pub fn get_pyth_price(
         let decimals = 10u64
             .checked_pow(exponent)
             .ok_or(LendingError::MathOverflow)?;
-        Decimal::from(price).try_div(decimals)?
-    };
-
-    Ok(market_price)
+        Decimal::from(price).try_div(decimals)
+    }
 }
 
 #[cfg(test)]
@@ -80,6 +97,7 @@ mod test {
     use super::*;
     use bytemuck::bytes_of_mut;
     use proptest::prelude::*;
+    use pyth_sdk_solana::state::Rational;
     use pyth_sdk_solana::state::{
         AccountType, CorpAction, PriceAccount, PriceInfo, PriceStatus, PriceType, MAGIC, VERSION_2,
     };
@@ -89,7 +107,7 @@ mod test {
     struct PythPriceTestCase {
         price_account: PriceAccount,
         clock: Clock,
-        expected_result: Result<Decimal, ProgramError>,
+        expected_result: Result<(Decimal, Decimal), ProgramError>,
     }
 
     fn pyth_price_cases() -> impl Strategy<Value = PythPriceTestCase> {
@@ -102,6 +120,11 @@ mod test {
                     atype: AccountType::Price as u32,
                     ptype: PriceType::Price,
                     expo: 10,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 10,
                         conf: 1,
@@ -126,6 +149,11 @@ mod test {
                     atype: AccountType::Price as u32,
                     ptype: PriceType::Price,
                     expo: 10,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 10,
                         conf: 1,
@@ -149,6 +177,11 @@ mod test {
                     atype: AccountType::Product as u32,
                     ptype: PriceType::Price,
                     expo: 10,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 10,
                         conf: 1,
@@ -174,6 +207,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 0,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 200,
                         conf: 1,
@@ -187,7 +225,7 @@ mod test {
                     slot: 240,
                     ..Clock::default()
                 },
-                expected_result: Ok(Decimal::from(2000_u64))
+                expected_result: Ok((Decimal::from(2000_u64), Decimal::from(110_u64)))
             }),
             // case 7: success. most recent price has status == unknown, previous price not stale
             Just(PythPriceTestCase {
@@ -198,6 +236,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 20,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 200,
                         conf: 1,
@@ -214,7 +257,7 @@ mod test {
                     slot: 240,
                     ..Clock::default()
                 },
-                expected_result: Ok(Decimal::from(1900_u64))
+                expected_result: Ok((Decimal::from(1900_u64), Decimal::from(110_u64)))
             }),
             // case 8: failure. most recent price is stale
             Just(PythPriceTestCase {
@@ -225,6 +268,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 0,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 200,
                         conf: 1,
@@ -250,6 +298,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 1,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 200,
                         conf: 1,
@@ -277,6 +330,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 1,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: -200,
                         conf: 1,
@@ -301,6 +359,11 @@ mod test {
                     ptype: PriceType::Price,
                     expo: 1,
                     timestamp: 1,
+                    ema_price: Rational {
+                        val: 11,
+                        numer: 110,
+                        denom: 10,
+                    },
                     agg: PriceInfo {
                         price: 200,
                         conf: 40,

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -141,7 +141,8 @@ impl Obligation {
 
     /// Calculate the maximum liquidity value that can be borrowed
     pub fn remaining_borrow_value(&self) -> Result<Decimal, ProgramError> {
-        self.allowed_borrow_value.try_sub(self.borrowed_value)
+        self.allowed_borrow_value
+            .try_sub(self.borrowed_value_upper_bound)
     }
 
     /// Calculate the maximum liquidation amount for a given liquidity

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -43,10 +43,15 @@ pub struct Obligation {
     /// Risk-adjusted upper bound market value of borrows.
     /// ie sum(b.borrowed_amount * max(b.current_spot_price, b.smoothed_price) * b.borrow_weight for b in borrows)
     pub borrowed_value_upper_bound: Decimal,
-    /// The maximum borrow value at the weighted average loan to value ratio using the minimum of
-    /// the spot price and the smoothed price
+    /// The maximum open borrow value.
+    /// ie sum(d.deposited_amount * d.ltv * min(d.current_spot_price, d.smoothed_price) for d in deposits)
+    /// if borrowed_value_upper_bound >= allowed_borrow_value, then the obligation is unhealthy and
+    /// borrows and withdraws are disabled.
     pub allowed_borrow_value: Decimal,
-    /// The dangerous borrow value at the weighted average liquidation threshold
+    /// The dangerous borrow value at the weighted average liquidation threshold.
+    /// ie sum(d.deposited_amount * d.liquidation_threshold * min(d.current_spot_price, d.smoothed_price)
+    /// for d in deposits)
+    /// if borrowed_value >= unhealthy_borrow_value, the obligation can be liquidated
     pub unhealthy_borrow_value: Decimal,
 }
 

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -71,6 +71,11 @@ impl Reserve {
             .unwrap()
     }
 
+    /// get loan to value ratio as a Rate
+    pub fn loan_to_value_ratio(&self) -> Rate {
+        Rate::from_percent(self.config.loan_to_value_ratio)
+    }
+
     /// find current market value of tokens
     pub fn market_value(&self, liquidity_amount: Decimal) -> Result<Decimal, ProgramError> {
         self.liquidity


### PR DESCRIPTION
Main Changes
- Add a smoothed_market_price to Reserve that is used to limit borrows and withdraws in cases where smoothed price and spot price diverge. 
- allowed_borrow_value now uses the min(smoothed_market_price, current spot price)
- new field on obligation called borrowed_value_upper_bound that uses max(smoothed_market_price, current spot price)

Affected instructions  

Refresh Reserve
- special case handilng for switchboard-only reserves  
- for reserves that use pyth, the smoothed price field only gets updated when the pyth key is given  
- for reserves that only use switchboard, the smooth price field gets set to the market price, essentially making this PR useless for switchboard-only reserves  

Refresh Obligation
- modified ways to calculate allowed borrow value  
- add new field to calculate borrowed_value_upper_bound  

Withdraw Obligation Collateral + Withdraw Obligation Collateral and Redeem Reserve Liquidity
- the amount you can withdraw must be inversely related to (allowed borrow value - borrowed value upper bound)  

Borrow Obligation Liquidity
- need to use the max(spot price, ema price) to calculate max borrow amount  

Note that liquidations still using current spot prices and have no dependence on the new smoothed_price value or borrowed_value_upper_bound