### PR TITLE
Isolated Tier Assets

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -7,8 +7,8 @@ use solend_sdk::{
         liquidate_obligation_and_redeem_reserve_collateral, redeem_reserve_collateral,
         refresh_obligation, refresh_reserve,
     },
-    state::AssetType,
     state::Obligation,
+    state::ReserveType,
 };
 
 mod lending_state;
@@ -956,7 +956,7 @@ fn main() {
                     protocol_liquidation_fee,
                     protocol_take_rate,
                     added_borrow_weight_bps: 10000,
-                    asset_type: AssetType::Regular,
+                    asset_type: ReserveType::Regular,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -7,6 +7,7 @@ use solend_sdk::{
         liquidate_obligation_and_redeem_reserve_collateral, redeem_reserve_collateral,
         refresh_obligation, refresh_reserve,
     },
+    state::AssetType,
     state::Obligation,
 };
 
@@ -955,6 +956,7 @@ fn main() {
                     protocol_liquidation_fee,
                     protocol_take_rate,
                     added_borrow_weight_bps: 10000,
+                    asset_type: AssetType::Regular,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -956,7 +956,7 @@ fn main() {
                     protocol_liquidation_fee,
                     protocol_take_rate,
                     added_borrow_weight_bps: 10000,
-                    asset_type: ReserveType::Regular,
+                    reserve_type: ReserveType::Regular,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -973,7 +973,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
             return Err(LendingError::ReserveStale.into());
         }
 
-        if borrow_reserve.config.asset_type == ReserveType::Isolated {
+        if borrow_reserve.config.reserve_type == ReserveType::Isolated {
             borrowing_isolated_asset = true;
         }
 
@@ -1474,7 +1474,7 @@ fn process_borrow_obligation_liquidity(
         return Err(LendingError::InvalidMarketAuthority.into());
     }
 
-    match borrow_reserve.config.asset_type {
+    match borrow_reserve.config.reserve_type {
         ReserveType::Isolated => match obligation.borrows.len() {
             0 => {}
             1 => {

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -4,12 +4,12 @@ use crate::{
     self as solend_program,
     error::LendingError,
     instruction::LendingInstruction,
-    math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub, WAD},
+    math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
     oracles::get_pyth_price,
     state::{
-        CalculateBorrowResult, CalculateLiquidationResult, CalculateRepayResult,
-        InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
-        NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, Reserve,
+        validate_reserve_config, CalculateBorrowResult, CalculateLiquidationResult,
+        CalculateRepayResult, InitLendingMarketParams, InitObligationParams, InitReserveParams,
+        LendingMarket, NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, Reserve,
         ReserveCollateral, ReserveConfig, ReserveLiquidity,
     },
 };
@@ -30,7 +30,7 @@ use solana_program::{
         Sysvar,
     },
 };
-use solend_sdk::state::{RateLimiter, RateLimiterConfig};
+use solend_sdk::state::{AssetType, RateLimiter, RateLimiterConfig};
 use solend_sdk::{switchboard_v2_devnet, switchboard_v2_mainnet};
 use spl_token::state::Mint;
 use std::{cmp::min, result::Result};
@@ -946,6 +946,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
             unhealthy_borrow_value.try_add(market_value.try_mul(liquidation_threshold_rate)?)?;
     }
 
+    let mut borrowing_isolated_asset = false;
     for (index, liquidity) in obligation.borrows.iter_mut().enumerate() {
         let borrow_reserve_info = next_account_info(account_info_iter)?;
         if borrow_reserve_info.owner != program_id {
@@ -972,6 +973,10 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
             return Err(LendingError::ReserveStale.into());
         }
 
+        if borrow_reserve.config.asset_type == AssetType::Isolated {
+            borrowing_isolated_asset = true;
+        }
+
         liquidity.accrue_interest(borrow_reserve.liquidity.cumulative_borrow_rate_wads)?;
 
         let market_value = borrow_reserve.market_value(liquidity.borrowed_amount_wads)?;
@@ -993,6 +998,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     obligation.deposited_value = deposited_value;
     obligation.borrowed_value = borrowed_value;
     obligation.borrowed_value_upper_bound = borrowed_value_upper_bound;
+    obligation.borrowing_isolated_asset = borrowing_isolated_asset;
 
     let global_unhealthy_borrow_value = Decimal::from(70000000u64);
     let global_allowed_borrow_value = Decimal::from(65000000u64);
@@ -1467,6 +1473,33 @@ fn process_borrow_obligation_liquidity(
         );
         return Err(LendingError::InvalidMarketAuthority.into());
     }
+
+    match borrow_reserve.config.asset_type {
+        AssetType::Isolated => match obligation.borrows.len() {
+            0 => {}
+            1 => {
+                if &obligation.borrows[0].borrow_reserve != borrow_reserve_info.key {
+                    msg!("If you want to borrow an isolated tier asset, there can't be any other borrows in your obligation");
+                    return Err(LendingError::IsolatedTierAssetViolation.into());
+                }
+            }
+            // it's possible that the obligation already has a borrow from this reserve (consider
+            // case the where we change a reserve asset type from regular to isolated), but in that
+            // case we don't want to let more borrows happen anyways.
+            _ => {
+                msg!("If you want to borrow an isolated tier asset, there can't be any other borrows in your obligation");
+                return Err(LendingError::IsolatedTierAssetViolation.into());
+            }
+        },
+        AssetType::Regular => {
+            if obligation.borrowing_isolated_asset {
+                msg!(
+                    "Cannot borrow a regular tier asset if you have an isolated tier asset borrow"
+                );
+                return Err(LendingError::IsolatedTierAssetViolation.into());
+            }
+        }
+    };
 
     let remaining_borrow_value = obligation
         .remaining_borrow_value()
@@ -2824,54 +2857,6 @@ fn spl_token_burn(params: TokenBurnParams<'_, '_>) -> ProgramResult {
         authority_signer_seeds,
     );
     result.map_err(|_| LendingError::TokenBurnFailed.into())
-}
-
-/// validates reserve configs
-#[inline(always)]
-fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
-    if config.optimal_utilization_rate > 100 {
-        msg!("Optimal utilization rate must be in range [0, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.loan_to_value_ratio >= 100 {
-        msg!("Loan to value ratio must be in range [0, 100)");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.liquidation_bonus > 100 {
-        msg!("Liquidation bonus must be in range [0, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.liquidation_threshold < config.loan_to_value_ratio
-        || config.liquidation_threshold > 100
-    {
-        msg!("Liquidation threshold must be in range [LTV, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.optimal_borrow_rate < config.min_borrow_rate {
-        msg!("Optimal borrow rate must be >= min borrow rate");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.optimal_borrow_rate > config.max_borrow_rate {
-        msg!("Optimal borrow rate must be <= max borrow rate");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.fees.borrow_fee_wad >= WAD {
-        msg!("Borrow fee must be in range [0, 1_000_000_000_000_000_000)");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.fees.host_fee_percentage > 100 {
-        msg!("Host fee percentage must be in range [0, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.protocol_liquidation_fee > 100 {
-        msg!("Protocol liquidation fee must be in range [0, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    if config.protocol_take_rate > 100 {
-        msg!("Protocol take rate must be in range [0, 100]");
-        return Err(LendingError::InvalidConfig.into());
-    }
-    Ok(())
 }
 
 /// validates pyth AccountInfos

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -30,7 +30,7 @@ use solana_program::{
         Sysvar,
     },
 };
-use solend_sdk::state::{AssetType, RateLimiter, RateLimiterConfig};
+use solend_sdk::state::{RateLimiter, RateLimiterConfig, ReserveType};
 use solend_sdk::{switchboard_v2_devnet, switchboard_v2_mainnet};
 use spl_token::state::Mint;
 use std::{cmp::min, result::Result};
@@ -973,7 +973,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
             return Err(LendingError::ReserveStale.into());
         }
 
-        if borrow_reserve.config.asset_type == AssetType::Isolated {
+        if borrow_reserve.config.asset_type == ReserveType::Isolated {
             borrowing_isolated_asset = true;
         }
 
@@ -1475,7 +1475,7 @@ fn process_borrow_obligation_liquidity(
     }
 
     match borrow_reserve.config.asset_type {
-        AssetType::Isolated => match obligation.borrows.len() {
+        ReserveType::Isolated => match obligation.borrows.len() {
             0 => {}
             1 => {
                 if &obligation.borrows[0].borrow_reserve != borrow_reserve_info.key {
@@ -1491,7 +1491,7 @@ fn process_borrow_obligation_liquidity(
                 return Err(LendingError::IsolatedTierAssetViolation.into());
             }
         },
-        AssetType::Regular => {
+        ReserveType::Regular => {
             if obligation.borrowing_isolated_asset {
                 msg!(
                     "Cannot borrow a regular tier asset if you have an isolated tier asset borrow"

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -54,7 +54,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
         added_borrow_weight_bps: 0,
-        asset_type: ReserveType::Regular,
+        reserve_type: ReserveType::Regular,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -20,7 +20,7 @@ use solend_program::{
         init_obligation, liquidate_obligation, refresh_obligation, refresh_reserve,
         withdraw_obligation_collateral_and_redeem_reserve_collateral,
     },
-    state::{Obligation, ReserveConfig, ReserveFees},
+    state::{AssetType, Obligation, ReserveConfig, ReserveFees},
 };
 
 use spl_token::state::Mint;
@@ -54,6 +54,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
         added_borrow_weight_bps: 0,
+        asset_type: AssetType::Regular,
     }
 }
 
@@ -68,6 +69,10 @@ pub mod usdt_mint {
 pub mod wsol_mint {
     // fake mint, not the real wsol bc i can't mint wsol programmatically
     solana_program::declare_id!("So1m5eppzgokXLBt9Cg8KCMPWhHfTzVaGh26Y415MRG");
+}
+
+pub mod bonk_mint {
+    solana_program::declare_id!("bonk99WdRCGrh56xQaeQuRMpMHgiNZEfVoZ53DJAoHS");
 }
 
 trait AddPacked {

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -20,7 +20,7 @@ use solend_program::{
         init_obligation, liquidate_obligation, refresh_obligation, refresh_reserve,
         withdraw_obligation_collateral_and_redeem_reserve_collateral,
     },
-    state::{AssetType, Obligation, ReserveConfig, ReserveFees},
+    state::{Obligation, ReserveConfig, ReserveFees, ReserveType},
 };
 
 use spl_token::state::Mint;
@@ -54,7 +54,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         protocol_liquidation_fee: 0,
         protocol_take_rate: 0,
         added_borrow_weight_bps: 0,
-        asset_type: AssetType::Regular,
+        asset_type: ReserveType::Regular,
     }
 }
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -90,6 +90,7 @@ impl SolendProgramTest {
         add_mint(&mut test, usdc_mint::id(), 6, authority.pubkey());
         add_mint(&mut test, usdt_mint::id(), 6, authority.pubkey());
         add_mint(&mut test, wsol_mint::id(), 9, authority.pubkey());
+        add_mint(&mut test, bonk_mint::id(), 5, authority.pubkey());
 
         let mut context = test.start_with_context().await;
         let rent = context.banks_client.get_rent().await.unwrap();
@@ -102,6 +103,7 @@ impl SolendProgramTest {
                 (usdc_mint::id(), None),
                 (wsol_mint::id(), None),
                 (usdt_mint::id(), None),
+                (bonk_mint::id(), None),
             ]),
         }
     }
@@ -1514,6 +1516,7 @@ pub async fn custom_scenario(
     Vec<Info<Reserve>>,
     Info<Obligation>,
     User,
+    User,
 ) {
     let mut test = SolendProgramTest::start_new().await;
     let mints_and_liquidity_amounts = reserve_args
@@ -1628,7 +1631,27 @@ pub async fn custom_scenario(
             .unwrap();
     }
 
-    (test, lending_market, reserves, obligation, obligation_owner)
+    lending_market
+        .refresh_obligation(&mut test, &obligation)
+        .await
+        .unwrap();
+    let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+
+    // load accounts into reserve
+    for reserve in reserves.iter_mut() {
+        *reserve = test.load_account(reserve.pubkey).await;
+    }
+
+    let lending_market = test.load_account(lending_market.pubkey).await;
+
+    (
+        test,
+        lending_market,
+        reserves,
+        obligation,
+        obligation_owner,
+        lending_market_owner,
+    )
 }
 
 pub fn find_reserve(reserves: &[Info<Reserve>], mint: &Pubkey) -> Option<Info<Reserve>> {

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -47,7 +47,8 @@ async fn test_success() {
             borrowed_value: Decimal::zero(),
             borrowed_value_upper_bound: Decimal::zero(),
             allowed_borrow_value: Decimal::zero(),
-            unhealthy_borrow_value: Decimal::zero()
+            unhealthy_borrow_value: Decimal::zero(),
+            borrowing_isolated_asset: false
         }
     );
 }

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -1,0 +1,478 @@
+#![cfg(feature = "test-bpf")]
+
+use crate::solend_program_test::custom_scenario;
+
+use crate::solend_program_test::ObligationArgs;
+use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
+
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+use solend_sdk::math::Decimal;
+
+use solend_program::state::AssetType;
+use solend_program::state::LastUpdate;
+use solend_program::state::{Obligation, ObligationLiquidity, ReserveConfig};
+use solend_program::NULL_PUBKEY;
+use solend_sdk::state::ReserveFees;
+mod helpers;
+
+use helpers::*;
+use solana_program_test::*;
+
+#[tokio::test]
+async fn test_refresh_obligation() {
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: -1,
+                    ema_price: 10,
+                    ema_conf: 1,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 0,
+                    liquidation_threshold: 0,
+                    fees: ReserveFees {
+                        host_fee_percentage: 0,
+                        ..ReserveFees::default()
+                    },
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    asset_type: AssetType::Isolated,
+
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![],
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    let wsol_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == wsol_mint::id())
+        .unwrap();
+
+    // borrow isolated tier asset
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            wsol_reserve,
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            LAMPORTS_PER_SOL,
+        )
+        .await
+        .unwrap();
+
+    lending_market
+        .refresh_obligation(&mut test, &obligation)
+        .await
+        .unwrap();
+
+    let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
+
+    assert_eq!(
+        obligation_post.account,
+        Obligation {
+            last_update: LastUpdate {
+                slot: 1001,
+                stale: false
+            },
+            borrows: vec![ObligationLiquidity {
+                borrow_reserve: wsol_reserve.pubkey,
+                cumulative_borrow_rate_wads: Decimal::one(),
+                borrowed_amount_wads: Decimal::from(LAMPORTS_PER_SOL),
+                market_value: Decimal::from(10u64),
+            }],
+            borrowed_value: Decimal::from(10u64),
+            borrowed_value_upper_bound: Decimal::from(10u64),
+            borrowing_isolated_asset: true,
+            ..obligation.account
+        }
+    );
+}
+
+#[tokio::test]
+async fn borrow_isolated_asset() {
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: bonk_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 0,
+                    liquidation_threshold: 0,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    asset_type: AssetType::Isolated,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 1_000_000,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: -6,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![],
+        },
+    )
+    .await;
+
+    let bonk_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == bonk_mint::id())
+        .unwrap();
+
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            bonk_reserve,
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            10,
+        )
+        .await
+        .unwrap();
+
+    // borrow again
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            bonk_reserve,
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn borrow_isolated_asset_invalid() {
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 50,
+                    liquidation_threshold: 55,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: bonk_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 0,
+                    liquidation_threshold: 0,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    asset_type: AssetType::Isolated,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 1_000_000,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: -6,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![(wsol_mint::id(), 1)],
+        },
+    )
+    .await;
+
+    // try to borrow 1 unit of bonk
+    let bonk_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == bonk_mint::id())
+        .unwrap();
+
+    let err = lending_market
+        .borrow_obligation_liquidity(&mut test, bonk_reserve, &obligation, &user, &NULL_PUBKEY, 1)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            4,
+            InstructionError::Custom(LendingError::IsolatedTierAssetViolation as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn borrow_regular_asset_invalid() {
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 50,
+                    liquidation_threshold: 55,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+            ReserveArgs {
+                mint: bonk_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 0,
+                    liquidation_threshold: 0,
+                    fees: ReserveFees::default(),
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    protocol_liquidation_fee: 0,
+                    asset_type: AssetType::Isolated,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 1_000_000,
+                price: PriceArgs {
+                    price: 1,
+                    conf: 0,
+                    expo: -6,
+                    ema_price: 1,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &ObligationArgs {
+            deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+            borrows: vec![(bonk_mint::id(), 1)],
+        },
+    )
+    .await;
+
+    // borrow LAMPORTS_PER_SOL wsol
+    let wsol_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == wsol_mint::id())
+        .unwrap();
+
+    // should error bc we are already borrowing bonk, which is an isolated tier asset
+    let err = lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            wsol_reserve,
+            &obligation,
+            &user,
+            &NULL_PUBKEY,
+            LAMPORTS_PER_SOL,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            4,
+            InstructionError::Custom(LendingError::IsolatedTierAssetViolation as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn invalid_borrow_due_to_reserve_config_change() {
+    let (mut test, lending_market, reserves, obligation, user, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: test_reserve_config(),
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 1,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 1,
+                        ema_conf: 0,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 50,
+                        liquidation_threshold: 55,
+                        fees: ReserveFees::default(),
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        protocol_liquidation_fee: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+                ReserveArgs {
+                    mint: bonk_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 0,
+                        liquidation_threshold: 0,
+                        fees: ReserveFees::default(),
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        protocol_liquidation_fee: 0,
+                        asset_type: AssetType::Regular, // regular for now
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 1_000_000,
+                    price: PriceArgs {
+                        price: 1,
+                        conf: 0,
+                        expo: -6,
+                        ema_price: 1,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+                borrows: vec![(bonk_mint::id(), 1), (wsol_mint::id(), LAMPORTS_PER_SOL)],
+            },
+        )
+        .await;
+
+    // update reserve config such that the bonk reserve is now of asset type isolated
+    let bonk_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == bonk_mint::id())
+        .unwrap();
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            bonk_reserve,
+            ReserveConfig {
+                asset_type: AssetType::Isolated,
+                ..bonk_reserve.account.config
+            },
+            bonk_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // borrow 1 more unit of BONK. this should fail because the reserve is now isolated but the
+    // obligation has two borrows
+    let err = lending_market
+        .borrow_obligation_liquidity(&mut test, bonk_reserve, &obligation, &user, &NULL_PUBKEY, 1)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            4,
+            InstructionError::Custom(LendingError::IsolatedTierAssetViolation as u32)
+        )
+    );
+}

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -49,7 +49,7 @@ async fn test_refresh_obligation() {
                     },
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
 
                     ..test_reserve_config()
                 },
@@ -143,7 +143,7 @@ async fn borrow_isolated_asset() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -239,7 +239,7 @@ async fn borrow_isolated_asset_invalid() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -324,7 +324,7 @@ async fn borrow_regular_asset_invalid() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -419,7 +419,7 @@ async fn invalid_borrow_due_to_reserve_config_change() {
                         optimal_borrow_rate: 0,
                         max_borrow_rate: 0,
                         protocol_liquidation_fee: 0,
-                        asset_type: ReserveType::Regular, // regular for now
+                        reserve_type: ReserveType::Regular, // regular for now
                         ..test_reserve_config()
                     },
                     liquidity_amount: 1_000_000,
@@ -451,7 +451,7 @@ async fn invalid_borrow_due_to_reserve_config_change() {
             &lending_market_owner,
             bonk_reserve,
             ReserveConfig {
-                asset_type: ReserveType::Isolated,
+                reserve_type: ReserveType::Isolated,
                 ..bonk_reserve.account.config
             },
             bonk_reserve.account.rate_limiter.config,

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -70,6 +70,14 @@ async fn test_refresh_obligation() {
     )
     .await;
 
+    lending_market
+        .refresh_obligation(&mut test, &obligation)
+        .await
+        .unwrap();
+
+    let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+    assert!(!obligation.account.borrowing_isolated_asset);
+
     test.advance_clock_by_slots(1).await;
 
     let wsol_reserve = reserves

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -12,8 +12,8 @@ use solana_sdk::transaction::TransactionError;
 use solend_program::error::LendingError;
 use solend_sdk::math::Decimal;
 
-use solend_program::state::AssetType;
 use solend_program::state::LastUpdate;
+use solend_program::state::ReserveType;
 use solend_program::state::{Obligation, ObligationLiquidity, ReserveConfig};
 use solend_program::NULL_PUBKEY;
 use solend_sdk::state::ReserveFees;
@@ -49,7 +49,7 @@ async fn test_refresh_obligation() {
                     },
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
 
                     ..test_reserve_config()
                 },
@@ -143,7 +143,7 @@ async fn borrow_isolated_asset() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -239,7 +239,7 @@ async fn borrow_isolated_asset_invalid() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -324,7 +324,7 @@ async fn borrow_regular_asset_invalid() {
                     optimal_borrow_rate: 0,
                     max_borrow_rate: 0,
                     protocol_liquidation_fee: 0,
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 1_000_000,
@@ -419,7 +419,7 @@ async fn invalid_borrow_due_to_reserve_config_change() {
                         optimal_borrow_rate: 0,
                         max_borrow_rate: 0,
                         protocol_liquidation_fee: 0,
-                        asset_type: AssetType::Regular, // regular for now
+                        asset_type: ReserveType::Regular, // regular for now
                         ..test_reserve_config()
                     },
                     liquidity_amount: 1_000_000,
@@ -451,7 +451,7 @@ async fn invalid_borrow_due_to_reserve_config_change() {
             &lending_market_owner,
             bonk_reserve,
             ReserveConfig {
-                asset_type: AssetType::Isolated,
+                asset_type: ReserveType::Isolated,
                 ..bonk_reserve.account.config
             },
             bonk_reserve.account.rate_limiter.config,

--- a/token-lending/program/tests/two_prices.rs
+++ b/token-lending/program/tests/two_prices.rs
@@ -29,7 +29,7 @@ use std::collections::HashSet;
 
 #[tokio::test]
 async fn test_borrow() {
-    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
         &[
             ReserveArgs {
                 mint: usdc_mint::id(),
@@ -152,7 +152,7 @@ async fn test_borrow() {
 
 #[tokio::test]
 async fn test_withdraw() {
-    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
         &[
             ReserveArgs {
                 mint: usdc_mint::id(),
@@ -298,7 +298,7 @@ async fn test_withdraw() {
 
 #[tokio::test]
 async fn test_liquidation_doesnt_use_smoothed_price() {
-    let (mut test, lending_market, reserves, obligation, user) = custom_scenario(
+    let (mut test, lending_market, reserves, obligation, user, _) = custom_scenario(
         &[
             ReserveArgs {
                 mint: usdc_mint::id(),

--- a/token-lending/sdk/src/error.rs
+++ b/token-lending/sdk/src/error.rs
@@ -195,6 +195,11 @@ pub enum LendingError {
     /// Outflow Rate Limit Exceeded
     #[error("Outflow Rate Limit Exceeded")]
     OutflowRateLimitExceeded,
+
+    // 55
+    /// Isolated Tier Asset Violation
+    #[error("Isolated Tier Asset Violation")]
+    IsolatedTierAssetViolation,
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1,6 +1,6 @@
 //! Instruction types
 
-use crate::state::AssetType;
+use crate::state::ReserveType;
 use crate::{
     error::LendingError,
     state::{RateLimiterConfig, ReserveConfig, ReserveFees},
@@ -535,7 +535,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
-                        asset_type: AssetType::from_u8(asset_type).unwrap(),
+                        asset_type: ReserveType::from_u8(asset_type).unwrap(),
                     },
                 }
             }
@@ -623,7 +623,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
-                        asset_type: AssetType::from_u8(asset_type).unwrap(),
+                        asset_type: ReserveType::from_u8(asset_type).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -1593,7 +1593,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
-                        asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                 };
 
@@ -1749,7 +1749,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
-                        asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration: rng.gen::<u64>(),

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1,9 +1,11 @@
 //! Instruction types
 
+use crate::state::AssetType;
 use crate::{
     error::LendingError,
     state::{RateLimiterConfig, ReserveConfig, ReserveFees},
 };
+use num_traits::FromPrimitive;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     msg,
@@ -510,7 +512,8 @@ impl LendingInstruction {
                 let (fee_receiver, rest) = Self::unpack_pubkey(rest)?;
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
                 let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
-                let (added_borrow_weight_bps, _rest) = Self::unpack_u64(rest)?;
+                let (added_borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
+                let (asset_type, _rest) = Self::unpack_u8(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -532,6 +535,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
+                        asset_type: AssetType::from_u8(asset_type).unwrap(),
                     },
                 }
             }
@@ -595,6 +599,7 @@ impl LendingInstruction {
                 let (protocol_liquidation_fee, rest) = Self::unpack_u8(rest)?;
                 let (protocol_take_rate, rest) = Self::unpack_u8(rest)?;
                 let (added_borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
+                let (asset_type, rest) = Self::unpack_u8(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
 
@@ -618,6 +623,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
+                        asset_type: AssetType::from_u8(asset_type).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -745,6 +751,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps: borrow_weight_bps,
+                        asset_type,
                     },
             } => {
                 buf.push(2);
@@ -765,6 +772,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&protocol_take_rate.to_le_bytes());
                 buf.extend_from_slice(&borrow_weight_bps.to_le_bytes());
+                buf.extend_from_slice(&(asset_type as u8).to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -836,6 +844,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&config.protocol_take_rate.to_le_bytes());
                 buf.extend_from_slice(&config.added_borrow_weight_bps.to_le_bytes());
+                buf.extend_from_slice(&(config.asset_type as u8).to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }
@@ -1584,6 +1593,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
+                        asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                 };
 
@@ -1739,6 +1749,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
+                        asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration: rng.gen::<u64>(),

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -535,7 +535,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
-                        asset_type: ReserveType::from_u8(asset_type).unwrap(),
+                        reserve_type: ReserveType::from_u8(asset_type).unwrap(),
                     },
                 }
             }
@@ -623,7 +623,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps,
-                        asset_type: ReserveType::from_u8(asset_type).unwrap(),
+                        reserve_type: ReserveType::from_u8(asset_type).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -751,7 +751,7 @@ impl LendingInstruction {
                         protocol_liquidation_fee,
                         protocol_take_rate,
                         added_borrow_weight_bps: borrow_weight_bps,
-                        asset_type,
+                        reserve_type: asset_type,
                     },
             } => {
                 buf.push(2);
@@ -844,7 +844,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&config.protocol_liquidation_fee.to_le_bytes());
                 buf.extend_from_slice(&config.protocol_take_rate.to_le_bytes());
                 buf.extend_from_slice(&config.added_borrow_weight_bps.to_le_bytes());
-                buf.extend_from_slice(&(config.asset_type as u8).to_le_bytes());
+                buf.extend_from_slice(&(config.reserve_type as u8).to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }
@@ -1593,7 +1593,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
-                        asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                 };
 
@@ -1749,7 +1749,7 @@ mod test {
                         protocol_liquidation_fee: rng.gen::<u8>(),
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
-                        asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration: rng.gen::<u64>(),

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -781,8 +781,8 @@ pub struct ReserveConfig {
     /// Added borrow weight in basis points. THIS FIELD SHOULD NEVER BE USED DIRECTLY. Always use
     /// borrow_weight()
     pub added_borrow_weight_bps: u64,
-    /// Asset Type of the reserve (Regular, Isolated)
-    pub asset_type: AssetType,
+    /// Type of the reserve (Regular, Isolated)
+    pub asset_type: ReserveType,
 }
 
 /// validates reserve configs
@@ -831,7 +831,7 @@ pub fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
         return Err(LendingError::InvalidConfig.into());
     }
 
-    if config.asset_type == AssetType::Isolated
+    if config.asset_type == ReserveType::Isolated
         && !(config.loan_to_value_ratio == 0 && config.liquidation_threshold == 0)
     {
         msg!("open/close LTV must be 0 for isolated reserves");
@@ -842,7 +842,7 @@ pub fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, FromPrimitive)]
 /// Asset Type of the reserve
-pub enum AssetType {
+pub enum ReserveType {
     #[default]
     /// this asset can be used as collateral
     Regular = 0,
@@ -1247,7 +1247,7 @@ impl Pack for Reserve {
                 protocol_liquidation_fee: u8::from_le_bytes(*config_protocol_liquidation_fee),
                 protocol_take_rate: u8::from_le_bytes(*config_protocol_take_rate),
                 added_borrow_weight_bps: u64::from_le_bytes(*config_added_borrow_weight_bps),
-                asset_type: AssetType::from_u8(config_asset_type[0]).unwrap(),
+                asset_type: ReserveType::from_u8(config_asset_type[0]).unwrap(),
             },
             rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
         })
@@ -1316,7 +1316,7 @@ mod test {
                     protocol_liquidation_fee: rng.gen(),
                     protocol_take_rate: rng.gen(),
                     added_borrow_weight_bps: rng.gen(),
-                    asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                    asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                 },
                 rate_limiter: rand_rate_limiter(),
             };
@@ -1709,7 +1709,7 @@ mod test {
         prop_oneof![
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     loan_to_value_ratio: 1,
                     ..ReserveConfig::default()
                 },
@@ -1717,7 +1717,7 @@ mod test {
             }),
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     liquidation_threshold: 1,
                     ..ReserveConfig::default()
                 },
@@ -1725,7 +1725,7 @@ mod test {
             }),
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: AssetType::Isolated,
+                    asset_type: ReserveType::Isolated,
                     loan_to_value_ratio: 0,
                     liquidation_threshold: 0,
                     ..ReserveConfig::default()

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -4,6 +4,8 @@ use crate::{
     math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
 };
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 use solana_program::{
     clock::Slot,
     entrypoint::ProgramResult,
@@ -779,6 +781,73 @@ pub struct ReserveConfig {
     /// Added borrow weight in basis points. THIS FIELD SHOULD NEVER BE USED DIRECTLY. Always use
     /// borrow_weight()
     pub added_borrow_weight_bps: u64,
+    /// Asset Type of the reserve (Regular, Isolated)
+    pub asset_type: AssetType,
+}
+
+/// validates reserve configs
+#[inline(always)]
+pub fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
+    if config.optimal_utilization_rate > 100 {
+        msg!("Optimal utilization rate must be in range [0, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.loan_to_value_ratio >= 100 {
+        msg!("Loan to value ratio must be in range [0, 100)");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.liquidation_bonus > 100 {
+        msg!("Liquidation bonus must be in range [0, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.liquidation_threshold < config.loan_to_value_ratio
+        || config.liquidation_threshold > 100
+    {
+        msg!("Liquidation threshold must be in range [LTV, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.optimal_borrow_rate < config.min_borrow_rate {
+        msg!("Optimal borrow rate must be >= min borrow rate");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.optimal_borrow_rate > config.max_borrow_rate {
+        msg!("Optimal borrow rate must be <= max borrow rate");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.fees.borrow_fee_wad >= WAD {
+        msg!("Borrow fee must be in range [0, 1_000_000_000_000_000_000)");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.fees.host_fee_percentage > 100 {
+        msg!("Host fee percentage must be in range [0, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.protocol_liquidation_fee > 100 {
+        msg!("Protocol liquidation fee must be in range [0, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    if config.protocol_take_rate > 100 {
+        msg!("Protocol take rate must be in range [0, 100]");
+        return Err(LendingError::InvalidConfig.into());
+    }
+
+    if config.asset_type == AssetType::Isolated
+        && !(config.loan_to_value_ratio == 0 && config.liquidation_threshold == 0)
+    {
+        msg!("open/close LTV must be 0 for isolated reserves");
+        return Err(LendingError::InvalidConfig.into());
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, FromPrimitive)]
+/// Asset Type of the reserve
+pub enum AssetType {
+    #[default]
+    /// this asset can be used as collateral
+    Regular = 0,
+    /// this asset cannot be used as collateral and can only be borrowed in isolation
+    Isolated = 1,
 }
 
 /// Additional fee information on a reserve
@@ -938,6 +1007,7 @@ impl Pack for Reserve {
             rate_limiter,
             config_added_borrow_weight_bps,
             liquidity_smoothed_market_price,
+            config_asset_type,
             _padding,
         ) = mut_array_refs![
             output,
@@ -976,7 +1046,8 @@ impl Pack for Reserve {
             RATE_LIMITER_LEN,
             8,
             16,
-            150
+            1,
+            149
         ];
 
         // reserve
@@ -1032,6 +1103,7 @@ impl Pack for Reserve {
         config_fee_receiver.copy_from_slice(self.config.fee_receiver.as_ref());
         *config_protocol_liquidation_fee = self.config.protocol_liquidation_fee.to_le_bytes();
         *config_protocol_take_rate = self.config.protocol_take_rate.to_le_bytes();
+        *config_asset_type = (self.config.asset_type as u8).to_le_bytes();
 
         self.rate_limiter.pack_into_slice(rate_limiter);
 
@@ -1078,6 +1150,7 @@ impl Pack for Reserve {
             rate_limiter,
             config_added_borrow_weight_bps,
             liquidity_smoothed_market_price,
+            config_asset_type,
             _padding,
         ) = array_refs![
             input,
@@ -1116,7 +1189,8 @@ impl Pack for Reserve {
             RATE_LIMITER_LEN,
             8,
             16,
-            150
+            1,
+            149
         ];
 
         let version = u8::from_le_bytes(*version);
@@ -1173,6 +1247,7 @@ impl Pack for Reserve {
                 protocol_liquidation_fee: u8::from_le_bytes(*config_protocol_liquidation_fee),
                 protocol_take_rate: u8::from_le_bytes(*config_protocol_take_rate),
                 added_borrow_weight_bps: u64::from_le_bytes(*config_added_borrow_weight_bps),
+                asset_type: AssetType::from_u8(config_asset_type[0]).unwrap(),
             },
             rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
         })
@@ -1241,6 +1316,7 @@ mod test {
                     protocol_liquidation_fee: rng.gen(),
                     protocol_take_rate: rng.gen(),
                     added_borrow_weight_bps: rng.gen(),
+                    asset_type: AssetType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                 },
                 rate_limiter: rand_rate_limiter(),
             };
@@ -1621,6 +1697,49 @@ mod test {
 
         assert_eq!(total_fee, 10); // 1% of 1000
         assert_eq!(host_fee, 0); // 0 host fee
+    }
+
+    #[derive(Debug, Clone)]
+    struct ReserveConfigTestCase {
+        config: ReserveConfig,
+        result: Result<(), ProgramError>,
+    }
+
+    fn reserve_config_test_cases() -> impl Strategy<Value = ReserveConfigTestCase> {
+        prop_oneof![
+            Just(ReserveConfigTestCase {
+                config: ReserveConfig {
+                    asset_type: AssetType::Isolated,
+                    loan_to_value_ratio: 1,
+                    ..ReserveConfig::default()
+                },
+                result: Err(LendingError::InvalidConfig.into()),
+            }),
+            Just(ReserveConfigTestCase {
+                config: ReserveConfig {
+                    asset_type: AssetType::Isolated,
+                    liquidation_threshold: 1,
+                    ..ReserveConfig::default()
+                },
+                result: Err(LendingError::InvalidConfig.into()),
+            }),
+            Just(ReserveConfigTestCase {
+                config: ReserveConfig {
+                    asset_type: AssetType::Isolated,
+                    loan_to_value_ratio: 0,
+                    liquidation_threshold: 0,
+                    ..ReserveConfig::default()
+                },
+                result: Ok(()),
+            })
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn test_validate_reserve_config(test_case in reserve_config_test_cases()) {
+            assert_eq!(validate_reserve_config(test_case.config), test_case.result);
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -782,7 +782,7 @@ pub struct ReserveConfig {
     /// borrow_weight()
     pub added_borrow_weight_bps: u64,
     /// Type of the reserve (Regular, Isolated)
-    pub asset_type: ReserveType,
+    pub reserve_type: ReserveType,
 }
 
 /// validates reserve configs
@@ -831,7 +831,7 @@ pub fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
         return Err(LendingError::InvalidConfig.into());
     }
 
-    if config.asset_type == ReserveType::Isolated
+    if config.reserve_type == ReserveType::Isolated
         && !(config.loan_to_value_ratio == 0 && config.liquidation_threshold == 0)
     {
         msg!("open/close LTV must be 0 for isolated reserves");
@@ -1103,7 +1103,7 @@ impl Pack for Reserve {
         config_fee_receiver.copy_from_slice(self.config.fee_receiver.as_ref());
         *config_protocol_liquidation_fee = self.config.protocol_liquidation_fee.to_le_bytes();
         *config_protocol_take_rate = self.config.protocol_take_rate.to_le_bytes();
-        *config_asset_type = (self.config.asset_type as u8).to_le_bytes();
+        *config_asset_type = (self.config.reserve_type as u8).to_le_bytes();
 
         self.rate_limiter.pack_into_slice(rate_limiter);
 
@@ -1247,7 +1247,7 @@ impl Pack for Reserve {
                 protocol_liquidation_fee: u8::from_le_bytes(*config_protocol_liquidation_fee),
                 protocol_take_rate: u8::from_le_bytes(*config_protocol_take_rate),
                 added_borrow_weight_bps: u64::from_le_bytes(*config_added_borrow_weight_bps),
-                asset_type: ReserveType::from_u8(config_asset_type[0]).unwrap(),
+                reserve_type: ReserveType::from_u8(config_asset_type[0]).unwrap(),
             },
             rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
         })
@@ -1316,7 +1316,7 @@ mod test {
                     protocol_liquidation_fee: rng.gen(),
                     protocol_take_rate: rng.gen(),
                     added_borrow_weight_bps: rng.gen(),
-                    asset_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                    reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                 },
                 rate_limiter: rand_rate_limiter(),
             };
@@ -1709,7 +1709,7 @@ mod test {
         prop_oneof![
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     loan_to_value_ratio: 1,
                     ..ReserveConfig::default()
                 },
@@ -1717,7 +1717,7 @@ mod test {
             }),
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     liquidation_threshold: 1,
                     ..ReserveConfig::default()
                 },
@@ -1725,7 +1725,7 @@ mod test {
             }),
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
-                    asset_type: ReserveType::Isolated,
+                    reserve_type: ReserveType::Isolated,
                     loan_to_value_ratio: 0,
                     liquidation_threshold: 0,
                     ..ReserveConfig::default()


### PR DESCRIPTION
An isolated tier asset can be borrowed if it is the only borrowed asset for a given obligation. Isolated tier assets also cannot be used as collateral (open / close ltvs must be set to 0).

Examples: If USDC, USDT are regular assets, but BONK, SLND are isolated tier assets:
- valid obligation states:
  - deposits: [USDC, USDT], borrows: [BONK]
  - deposits: [USDT], borrows: [BONK]
  - deposits: [USDC], borrows: [SLND]
- invalid obligation states:
  - deposits: [USDT], borrows: [BONK, USDC]
  - deposits: [USDC], borrows: [BONK, USDT]
  - deposits: [SLND], borrows: [USDC]
  - deposits: [USDC], borrows: [SLND, BONK]

State Changes
- ReserveConfig: new asset_type field
- Obligation: new borrowing_isolated_asset field

Instruction Changes
- initReserveConfig, updateReserveConfig: handle asset type changes
- refresh obligation: calculate borrowing_isolated_asset field
- borrow: handle isolated tier asset functionality

Main risks
- messing up packing logic
- accidentally initializing all reserves as isolated. this wouldn't cause immediate liquidation but it would halt all borrows. 