### PR TITLE
Liquidation changes

### DIFF
--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -1927,7 +1927,7 @@ mod test {
                 borrow_amount: 1,
                 borrow_market_value: Decimal::one(),
                 deposit_amount: 1,
-                deposit_market_value: Decimal::from(10u64), // $0.525
+                deposit_market_value: Decimal::from(10u64),
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(1u64),

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -360,7 +360,7 @@ impl Reserve {
                         // safety: technically this gives the liquidator more of a bonus, but this
                         // can happen at most once per ObligationLiquidity so I don't think this
                         // can be exploited to cause bad debt or anything.
-                        1
+                        1,
                     );
                 }
             }


### PR DESCRIPTION
Changes:
1. fully liquidate ObligationLiquidity if borrow value is less than 1 USD. 
2. correctly handle dust obligations in the case where the withdraw amount gets floored to zero.

Additional testing:
- would be nice to clone mainnet state, and verify that dust obligations get fully liquidated