### PR TITLE
On liq, assets must be repaid in order of borrow weight (decending)

### DIFF
--- a/ci/cargo-test-bpf.sh
+++ b/ci/cargo-test-bpf.sh
@@ -9,6 +9,7 @@ source ./ci/solana-version.sh
 export RUSTFLAGS="-D warnings"
 export RUSTBACKTRACE=1
 
+
 usage() {
   exitcode=0
   if [[ -n "$1" ]]; then

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -983,13 +983,18 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         }
 
         liquidity.accrue_interest(borrow_reserve.liquidity.cumulative_borrow_rate_wads)?;
+
+        let borrow_weight_and_pubkey = (
+            borrow_reserve.config.added_borrow_weight_bps,
+            borrow_reserve.liquidity.mint_pubkey,
+        );
         max_borrow_weight = match max_borrow_weight {
-            None => Some((borrow_reserve.borrow_weight(), index)),
-            Some((cur_max_weight, _)) => {
-                if borrow_reserve.borrow_weight() > cur_max_weight
-                    && liquidity.borrowed_amount_wads > Decimal::zero()
+            None => Some((borrow_weight_and_pubkey, index)),
+            Some((max_borrow_weight_and_pubkey, _)) => {
+                if liquidity.borrowed_amount_wads > Decimal::zero()
+                    && borrow_weight_and_pubkey > max_borrow_weight_and_pubkey
                 {
-                    Some((borrow_reserve.borrow_weight(), index))
+                    Some((borrow_weight_and_pubkey, index))
                 } else {
                     max_borrow_weight
                 }

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -884,9 +884,11 @@ impl Info<LendingMarket> {
         test: &mut SolendProgramTest,
         obligation: &Info<Obligation>,
     ) -> Result<(), BanksClientError> {
-        let instructions = self
-            .build_refresh_instructions(test, obligation, None)
-            .await;
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(80_000)];
+        instructions.extend(
+            self.build_refresh_instructions(test, obligation, None)
+                .await,
+        );
 
         test.process_transaction(&instructions, None).await
     }

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -1,11 +1,19 @@
 #![cfg(feature = "test-bpf")]
 
+use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::MintSupplyChange;
+use crate::solend_program_test::ObligationArgs;
+use crate::solend_program_test::ReserveArgs;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
 use solend_program::math::TrySub;
 use solend_program::state::LastUpdate;
 use solend_program::state::ObligationCollateral;
 use solend_program::state::ObligationLiquidity;
 use solend_program::state::ReserveConfig;
+use solend_sdk::state::ReserveFees;
 mod helpers;
 
 use crate::solend_program_test::scenario_1;
@@ -388,4 +396,145 @@ async fn test_success_insufficient_liquidity() {
             diff: -((available_amount * FRACTIONAL_TO_USDC) as i128)
         }])
     );
+}
+
+#[tokio::test]
+async fn test_liquidity_ordering() {
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: ReserveConfig {
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 0,
+                        liquidation_threshold: 0,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+                borrows: vec![
+                    (wsol_mint::id(), LAMPORTS_PER_SOL),
+                    (usdc_mint::id(), FRACTIONAL_TO_USDC),
+                ],
+            }],
+        )
+        .await;
+
+    let usdc_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == usdc_mint::id())
+        .unwrap();
+
+    let wsol_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == wsol_mint::id())
+        .unwrap();
+
+    // USDC depegs to 0.1
+    test.set_price(
+        &usdc_mint::id(),
+        &PriceArgs {
+            price: 1,
+            conf: 0,
+            expo: -1,
+            ema_price: 0,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    // update usdc borrow weight to 20_000
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            usdc_reserve,
+            ReserveConfig {
+                added_borrow_weight_bps: 50_000,
+                ..usdc_reserve.account.config
+            },
+            usdc_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    let liquidator = User::new_with_balances(
+        &mut test,
+        &[
+            (&wsol_mint::id(), 100 * LAMPORTS_TO_SOL),
+            (&usdc_reserve.account.collateral.mint_pubkey, 0),
+            (&usdc_mint::id(), 100 * LAMPORTS_TO_SOL),
+        ],
+    )
+    .await;
+
+    // this fails because wsol isn't the first borrow on the obligation
+    let err = lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            wsol_reserve,
+            usdc_reserve,
+            &obligations[0],
+            &liquidator,
+            u64::MAX,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            3,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
+    );
+
+    // this should pass though
+    lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            usdc_reserve,
+            usdc_reserve,
+            &obligations[0],
+            &liquidator,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
 }

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -401,6 +401,9 @@ async fn test_obligation_liquidity_ordering() {
         )
         .await
         .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
     lending_market
         .refresh_obligation(&mut test, &obligations[0])
         .await

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -2,7 +2,10 @@
 
 mod helpers;
 
+use crate::solend_program_test::custom_scenario;
+use crate::solend_program_test::ObligationArgs;
 use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
 use std::collections::HashSet;
 
 use helpers::solend_program_test::{setup_world, BalanceChecker, Info, SolendProgramTest, User};
@@ -276,5 +279,149 @@ async fn test_success() {
 
             ..obligation.account
         }
+    );
+}
+
+#[tokio::test]
+async fn test_obligation_liquidity_ordering() {
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: ReserveConfig {
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 0,
+                        liquidation_threshold: 0,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 100 * FRACTIONAL_TO_USDC)],
+                borrows: vec![
+                    (wsol_mint::id(), LAMPORTS_PER_SOL),
+                    (usdc_mint::id(), FRACTIONAL_TO_USDC),
+                ],
+            }],
+        )
+        .await;
+
+    // update usdc borrow weight to 20_000
+    let usdc_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == usdc_mint::id())
+        .unwrap();
+    let wsol_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == wsol_mint::id())
+        .unwrap();
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            usdc_reserve,
+            ReserveConfig {
+                added_borrow_weight_bps: 50_000,
+                ..usdc_reserve.account.config
+            },
+            usdc_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .refresh_obligation(&mut test, &obligations[0])
+        .await
+        .unwrap();
+
+    let obligation = test.load_account::<Obligation>(obligations[0].pubkey).await;
+    assert_eq!(
+        obligation.account.borrows,
+        vec![
+            ObligationLiquidity {
+                borrow_reserve: usdc_reserve.pubkey,
+                cumulative_borrow_rate_wads: Decimal::from(1u64),
+                borrowed_amount_wads: Decimal::from(FRACTIONAL_TO_USDC),
+                market_value: Decimal::from(1u64),
+            },
+            ObligationLiquidity {
+                borrow_reserve: wsol_reserve.pubkey,
+                cumulative_borrow_rate_wads: Decimal::from(1u64),
+                borrowed_amount_wads: Decimal::from(LAMPORTS_PER_SOL),
+                market_value: Decimal::from(10u64),
+            },
+        ]
+    );
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            wsol_reserve,
+            ReserveConfig {
+                added_borrow_weight_bps: 100_000,
+                ..wsol_reserve.account.config
+            },
+            wsol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+    lending_market
+        .refresh_obligation(&mut test, &obligations[0])
+        .await
+        .unwrap();
+
+    let obligation = test.load_account::<Obligation>(obligations[0].pubkey).await;
+    assert_eq!(
+        obligation.account.borrows,
+        vec![
+            ObligationLiquidity {
+                borrow_reserve: wsol_reserve.pubkey,
+                cumulative_borrow_rate_wads: Decimal::from(1u64),
+                borrowed_amount_wads: Decimal::from(LAMPORTS_PER_SOL),
+                market_value: Decimal::from(10u64),
+            },
+            ObligationLiquidity {
+                borrow_reserve: usdc_reserve.pubkey,
+                cumulative_borrow_rate_wads: Decimal::from(1u64),
+                borrowed_amount_wads: Decimal::from(FRACTIONAL_TO_USDC),
+                market_value: Decimal::from(1u64),
+            },
+        ]
     );
 }


### PR DESCRIPTION
Title is self-explanatory. 

Motivation:
- borrow weights are generally correlated with riskiness, so we want to the risky assets repaid first.
- when we want to deprecate a reserve, the borrow weight will be cranked to infinity to remove all borrows of that asset. When that happens, we don't want other assets to be repaid. we only want the deprecated asset to be repaid across all obligations. 

Risk:
adding extra constraints on liquidations carries a bit of risk. If for whatever reason, the highest borrow weighted repay asset _can't_ be repaid on a specific obligation, then liquidations for that account are bricked which would be pretty bad.

However, https://github.com/solendprotocol/solana-program-library/pull/139 should address all cases related to liquidation failures so we shouldn't run into any issues here. 