### PR TITLE
risk authority

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1577,6 +1577,7 @@ fn command_set_lending_market_owner_and_config(
                 max_outflow: rate_limiter_max_outflow
                     .unwrap_or(lending_market.rate_limiter.config.max_outflow),
             },
+            lending_market_owner_keypair.pubkey(), // FIXME: support risk authority
         )],
         Some(&config.fee_payer.pubkey()),
         &recent_blockhash,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2063,7 +2063,7 @@ fn process_update_reserve_config(
     let reserve_info = next_account_info(account_info_iter)?;
     let lending_market_info = next_account_info(account_info_iter)?;
     let lending_market_authority_info = next_account_info(account_info_iter)?;
-    let lending_market_owner_info = next_account_info(account_info_iter)?;
+    let signer_info = next_account_info(account_info_iter)?;
     let pyth_product_info = next_account_info(account_info_iter)?;
     let pyth_price_info = next_account_info(account_info_iter)?;
     let switchboard_feed_info = next_account_info(account_info_iter)?;
@@ -2091,19 +2091,12 @@ fn process_update_reserve_config(
         );
         return Err(LendingError::InvalidAccountOwner.into());
     }
-    if &lending_market.owner != lending_market_owner_info.key {
-        msg!("Lending market owner does not match the lending market owner provided");
-        return Err(LendingError::InvalidMarketOwner.into());
-    }
-    if !lending_market_owner_info.is_signer {
-        msg!("Lending market owner provided must be a signer");
-        return Err(LendingError::InvalidSigner.into());
-    }
 
     let authority_signer_seeds = &[
         lending_market_info.key.as_ref(),
         &[lending_market.bump_seed],
     ];
+
     let lending_market_authority_pubkey =
         Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if &lending_market_authority_pubkey != lending_market_authority_info.key {
@@ -2113,29 +2106,55 @@ fn process_update_reserve_config(
         return Err(LendingError::InvalidMarketAuthority.into());
     }
 
-    // if window duration or max outflow are different, then create a new rate limiter instance.
-    if rate_limiter_config != reserve.rate_limiter.config {
-        reserve.rate_limiter = RateLimiter::new(rate_limiter_config, Clock::get()?.slot);
+    if !signer_info.is_signer {
+        msg!("Lending market owner or risk authority provided must be a signer");
+        return Err(LendingError::InvalidSigner.into());
     }
 
-    if *pyth_price_info.key != reserve.liquidity.pyth_oracle_pubkey {
-        validate_pyth_keys(&lending_market, pyth_product_info, pyth_price_info)?;
-        reserve.liquidity.pyth_oracle_pubkey = *pyth_price_info.key;
+    if signer_info.key == &lending_market.owner {
+        // if window duration or max outflow are different, then create a new rate limiter instance.
+        if rate_limiter_config != reserve.rate_limiter.config {
+            reserve.rate_limiter = RateLimiter::new(rate_limiter_config, Clock::get()?.slot);
+        }
+
+        if *pyth_price_info.key != reserve.liquidity.pyth_oracle_pubkey {
+            validate_pyth_keys(&lending_market, pyth_product_info, pyth_price_info)?;
+            reserve.liquidity.pyth_oracle_pubkey = *pyth_price_info.key;
+        }
+
+        if *switchboard_feed_info.key != reserve.liquidity.switchboard_oracle_pubkey {
+            validate_switchboard_keys(&lending_market, switchboard_feed_info)?;
+            reserve.liquidity.switchboard_oracle_pubkey = *switchboard_feed_info.key;
+        }
+        if reserve.liquidity.switchboard_oracle_pubkey == solend_program::NULL_PUBKEY
+            && (*pyth_price_info.key == solend_program::NULL_PUBKEY
+                || *pyth_product_info.key == solend_program::NULL_PUBKEY)
+        {
+            msg!("At least one price oracle must have a non-null pubkey");
+            return Err(LendingError::InvalidOracleConfig.into());
+        }
+
+        reserve.config = config;
+    } else if signer_info.key == &lending_market.risk_authority {
+        // only can disable outflows
+        if rate_limiter_config.window_duration > 0 && rate_limiter_config.max_outflow == 0 {
+            reserve.rate_limiter = RateLimiter::new(rate_limiter_config, Clock::get()?.slot);
+        }
+
+        // only certain reserve config fields can be changed by the risk authority, and only in the
+        // safer direction for now
+        if config.borrow_limit < reserve.config.borrow_limit {
+            reserve.config.borrow_limit = config.borrow_limit;
+        }
+
+        if config.deposit_limit < reserve.config.deposit_limit {
+            reserve.config.deposit_limit = config.deposit_limit;
+        }
+    } else {
+        msg!("Signer must be the Lending market owner or risk authority");
+        return Err(LendingError::InvalidSigner.into());
     }
 
-    if *switchboard_feed_info.key != reserve.liquidity.switchboard_oracle_pubkey {
-        validate_switchboard_keys(&lending_market, switchboard_feed_info)?;
-        reserve.liquidity.switchboard_oracle_pubkey = *switchboard_feed_info.key;
-    }
-    if reserve.liquidity.switchboard_oracle_pubkey == solend_program::NULL_PUBKEY
-        && (*pyth_price_info.key == solend_program::NULL_PUBKEY
-            || *pyth_product_info.key == solend_program::NULL_PUBKEY)
-    {
-        msg!("At least one price oracle must have a non-null pubkey");
-        return Err(LendingError::InvalidOracleConfig.into());
-    }
-
-    reserve.config = config;
     Reserve::pack(reserve, &mut reserve_info.data.borrow_mut())?;
     Ok(())
 }

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -57,12 +57,14 @@ pub fn process_instruction(
         LendingInstruction::SetLendingMarketOwnerAndConfig {
             new_owner,
             rate_limiter_config,
+            risk_authority,
         } => {
             msg!("Instruction: Set Lending Market Owner");
             process_set_lending_market_owner_and_config(
                 program_id,
                 new_owner,
                 rate_limiter_config,
+                risk_authority,
                 accounts,
             )
         }
@@ -217,6 +219,7 @@ fn process_set_lending_market_owner_and_config(
     program_id: &Pubkey,
     new_owner: Pubkey,
     rate_limiter_config: RateLimiterConfig,
+    risk_authority: Pubkey,
     accounts: &[AccountInfo],
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -238,6 +241,7 @@ fn process_set_lending_market_owner_and_config(
     }
 
     lending_market.owner = new_owner;
+    lending_market.risk_authority = risk_authority;
 
     if rate_limiter_config != lending_market.rate_limiter.config {
         lending_market.rate_limiter = RateLimiter::new(rate_limiter_config, Clock::get()?.slot);

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1114,6 +1114,7 @@ impl Info<LendingMarket> {
         lending_market_owner: &User,
         new_owner: &Pubkey,
         config: RateLimiterConfig,
+        risk_authority: Pubkey,
     ) -> Result<(), BanksClientError> {
         let instructions = [set_lending_market_owner_and_config(
             solend_program::id(),
@@ -1121,6 +1122,7 @@ impl Info<LendingMarket> {
             lending_market_owner.keypair.pubkey(),
             *new_owner,
             config,
+            risk_authority,
         )];
 
         test.process_transaction(&instructions, Some(&[&lending_market_owner.keypair]))

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -647,7 +647,7 @@ impl Info<LendingMarket> {
     pub async fn update_reserve_config(
         &self,
         test: &mut SolendProgramTest,
-        lending_market_owner: &User,
+        signer: &User, // lending market owner or risk authority
         reserve: &Info<Reserve>,
         config: ReserveConfig,
         rate_limiter_config: RateLimiterConfig,
@@ -666,13 +666,13 @@ impl Info<LendingMarket> {
             rate_limiter_config,
             reserve.pubkey,
             self.pubkey,
-            lending_market_owner.keypair.pubkey(),
+            signer.keypair.pubkey(),
             oracle.pyth_product_pubkey,
             oracle.pyth_price_pubkey,
             oracle.switchboard_feed_pubkey.unwrap_or(NULL_PUBKEY),
         )];
 
-        test.process_transaction(&instructions, Some(&[&lending_market_owner.keypair]))
+        test.process_transaction(&instructions, Some(&[&signer.keypair]))
             .await
     }
 

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -36,6 +36,7 @@ async fn test_success() {
             oracle_program_id: mock_pyth_program::id(),
             switchboard_oracle_program_id: mock_pyth_program::id(),
             rate_limiter: RateLimiter::default(),
+            risk_authority: lending_market_owner.keypair.pubkey(),
         }
     );
 }

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -25,7 +25,7 @@ use solana_sdk::{
 };
 use solend_program::state::LastUpdate;
 use solend_program::state::RateLimiter;
-use solend_program::state::RateLimiterConfig;
+
 use solend_program::state::Reserve;
 use solend_program::state::ReserveCollateral;
 use solend_program::state::ReserveLiquidity;
@@ -298,101 +298,4 @@ async fn test_invalid_fees() {
             )
         );
     }
-}
-
-#[tokio::test]
-async fn test_update_reserve_config() {
-    let (mut test, lending_market, lending_market_owner) = setup().await;
-
-    let wsol_reserve = test
-        .init_reserve(
-            &lending_market,
-            &lending_market_owner,
-            &wsol_mint::id(),
-            &test_reserve_config(),
-            &Keypair::new(),
-            1000,
-            None,
-        )
-        .await
-        .unwrap();
-
-    let new_reserve_config = test_reserve_config();
-    let new_rate_limiter_config = RateLimiterConfig {
-        window_duration: 50,
-        max_outflow: 100,
-    };
-
-    lending_market
-        .update_reserve_config(
-            &mut test,
-            &lending_market_owner,
-            &wsol_reserve,
-            new_reserve_config,
-            new_rate_limiter_config,
-            None,
-        )
-        .await
-        .unwrap();
-
-    let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
-    assert_eq!(
-        wsol_reserve_post.account,
-        Reserve {
-            config: new_reserve_config,
-            rate_limiter: RateLimiter::new(new_rate_limiter_config, 1000),
-            ..wsol_reserve.account
-        }
-    );
-}
-
-#[tokio::test]
-async fn test_update_invalid_oracle_config() {
-    let (mut test, lending_market, lending_market_owner) = setup().await;
-    let wsol_reserve = test
-        .init_reserve(
-            &lending_market,
-            &lending_market_owner,
-            &wsol_mint::id(),
-            &test_reserve_config(),
-            &Keypair::new(),
-            1000,
-            None,
-        )
-        .await
-        .unwrap();
-
-    let oracle = test.mints.get(&wsol_mint::id()).unwrap().unwrap();
-
-    let new_reserve_config = test_reserve_config();
-    let new_rate_limiter_config = RateLimiterConfig {
-        window_duration: 50,
-        max_outflow: 100,
-    };
-
-    // Try setting both of the oracles to null: Should fail
-    let res = lending_market
-        .update_reserve_config(
-            &mut test,
-            &lending_market_owner,
-            &wsol_reserve,
-            new_reserve_config,
-            new_rate_limiter_config,
-            Some(&Oracle {
-                pyth_product_pubkey: oracle.pyth_product_pubkey,
-                pyth_price_pubkey: NULL_PUBKEY,
-                switchboard_feed_pubkey: Some(NULL_PUBKEY),
-            }),
-        )
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        res,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(LendingError::InvalidOracleConfig as u32)
-        )
-    );
 }

--- a/token-lending/program/tests/outflow_rate_limits.rs
+++ b/token-lending/program/tests/outflow_rate_limits.rs
@@ -130,6 +130,7 @@ async fn test_outflow_reserve() {
                 window_duration: 10,
                 max_outflow: 10,
             },
+            lending_market.account.risk_authority,
         )
         .await
         .unwrap();

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -32,6 +32,7 @@ async fn setup() -> (SolendProgramTest, Info<LendingMarket>, User) {
 async fn test_success() {
     let (mut test, lending_market, lending_market_owner) = setup().await;
     let new_owner = Keypair::new();
+    let new_risk_authority = Keypair::new();
     let new_config = RateLimiterConfig {
         max_outflow: 100,
         window_duration: 5,
@@ -43,6 +44,7 @@ async fn test_success() {
             &lending_market_owner,
             &new_owner.pubkey(),
             new_config,
+            new_risk_authority.pubkey(),
         )
         .await
         .unwrap();
@@ -66,6 +68,7 @@ async fn test_invalid_owner() {
     let (mut test, lending_market, _lending_market_owner) = setup().await;
     let invalid_owner = User::new_with_keypair(Keypair::new());
     let new_owner = Keypair::new();
+    let new_risk_authority = Keypair::new();
 
     let res = lending_market
         .set_lending_market_owner_and_config(
@@ -73,6 +76,7 @@ async fn test_invalid_owner() {
             &invalid_owner,
             &new_owner.pubkey(),
             RateLimiterConfig::default(),
+            new_risk_authority.pubkey(),
         )
         .await
         .unwrap_err()
@@ -91,6 +95,7 @@ async fn test_invalid_owner() {
 async fn test_owner_not_signer() {
     let (mut test, lending_market, _lending_market_owner) = setup().await;
     let new_owner = Pubkey::new_unique();
+    let new_risk_authority = Keypair::new();
     let res = test
         .process_transaction(
             &[Instruction {
@@ -102,6 +107,7 @@ async fn test_owner_not_signer() {
                 data: LendingInstruction::SetLendingMarketOwnerAndConfig {
                     new_owner,
                     rate_limiter_config: RateLimiterConfig::default(),
+                    risk_authority: new_risk_authority.pubkey(),
                 }
                 .pack(),
             }],

--- a/token-lending/program/tests/update_reserve_config.rs
+++ b/token-lending/program/tests/update_reserve_config.rs
@@ -1,0 +1,339 @@
+#![cfg(feature = "test-bpf")]
+
+use crate::solend_program_test::Oracle;
+use solana_sdk::instruction::AccountMeta;
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::PUBKEY_BYTES;
+use solend_sdk::instruction::LendingInstruction;
+mod helpers;
+
+use crate::solend_program_test::setup_world;
+use crate::solend_program_test::Info;
+use crate::solend_program_test::SolendProgramTest;
+use crate::solend_program_test::User;
+use helpers::*;
+use solana_program::example_mocks::solana_sdk::Pubkey;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    transaction::TransactionError,
+};
+use solend_program::state::RateLimiter;
+use solend_program::state::RateLimiterConfig;
+use solend_program::state::Reserve;
+use solend_program::NULL_PUBKEY;
+
+use solend_program::{error::LendingError, state::ReserveConfig};
+use solend_sdk::state::LendingMarket;
+
+async fn setup() -> (SolendProgramTest, Info<LendingMarket>, User) {
+    let (test, lending_market, _, _, lending_market_owner, _) =
+        setup_world(&test_reserve_config(), &test_reserve_config()).await;
+
+    (test, lending_market, lending_market_owner)
+}
+
+#[tokio::test]
+async fn test_update_reserve_config_owner() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+
+    let wsol_reserve = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &wsol_mint::id(),
+            &test_reserve_config(),
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let new_reserve_config = test_reserve_config();
+    let new_rate_limiter_config = RateLimiterConfig {
+        window_duration: 50,
+        max_outflow: 100,
+    };
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &wsol_reserve,
+            new_reserve_config,
+            new_rate_limiter_config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
+    assert_eq!(
+        wsol_reserve_post.account,
+        Reserve {
+            config: new_reserve_config,
+            rate_limiter: RateLimiter::new(new_rate_limiter_config, 1000),
+            ..wsol_reserve.account
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_update_reserve_config_risk_authority() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+
+    let wsol_reserve = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &wsol_mint::id(),
+            &ReserveConfig {
+                deposit_limit: 10000,
+                ..test_reserve_config()
+            },
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let risk_authority = User::new_with_keypair(Keypair::new());
+    lending_market
+        .set_lending_market_owner_and_config(
+            &mut test,
+            &lending_market_owner,
+            &lending_market_owner.keypair.pubkey(),
+            lending_market.account.rate_limiter.config,
+            risk_authority.keypair.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    let new_reserve_config = ReserveConfig {
+        borrow_limit: 20, // this should get updated on the reserve (safer than previous
+        // value)
+        deposit_limit: 10001, // this should NOT get updated on the reserve (prev limit was
+        // safer)
+        liquidation_threshold: 100, // this should NOT get updated (risk authority can't change
+        // this)
+        ..wsol_reserve.account.config
+    };
+
+    let new_rate_limiter_config = RateLimiterConfig {
+        window_duration: 50,
+        max_outflow: 0,
+    };
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &risk_authority,
+            &wsol_reserve,
+            new_reserve_config,
+            new_rate_limiter_config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
+    assert_eq!(
+        wsol_reserve_post.account,
+        Reserve {
+            config: ReserveConfig {
+                borrow_limit: 20,
+                ..wsol_reserve.account.config
+            },
+            rate_limiter: RateLimiter::new(new_rate_limiter_config, 1000),
+            ..wsol_reserve.account
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_update_invalid_oracle_config() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+    let wsol_reserve = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &wsol_mint::id(),
+            &test_reserve_config(),
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let oracle = test.mints.get(&wsol_mint::id()).unwrap().unwrap();
+
+    let new_reserve_config = test_reserve_config();
+    let new_rate_limiter_config = RateLimiterConfig {
+        window_duration: 50,
+        max_outflow: 100,
+    };
+
+    // Try setting both of the oracles to null: Should fail
+    let res = lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &wsol_reserve,
+            new_reserve_config,
+            new_rate_limiter_config,
+            Some(&Oracle {
+                pyth_product_pubkey: oracle.pyth_product_pubkey,
+                pyth_price_pubkey: NULL_PUBKEY,
+                switchboard_feed_pubkey: Some(NULL_PUBKEY),
+            }),
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        res,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidOracleConfig as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn test_update_reserve_config_invalid_signers() {
+    let (mut test, lending_market, lending_market_owner) = setup().await;
+
+    let wsol_reserve = test
+        .init_reserve(
+            &lending_market,
+            &lending_market_owner,
+            &wsol_mint::id(),
+            &test_reserve_config(),
+            &Keypair::new(),
+            1000,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let risk_authority = User::new_with_keypair(Keypair::new());
+    let rando = User::new_with_keypair(Keypair::new());
+
+    lending_market
+        .set_lending_market_owner_and_config(
+            &mut test,
+            &lending_market_owner,
+            &lending_market_owner.keypair.pubkey(),
+            lending_market.account.rate_limiter.config,
+            risk_authority.keypair.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    let new_reserve_config = ReserveConfig {
+        borrow_limit: 20,
+        liquidation_threshold: 100,
+        ..wsol_reserve.account.config
+    };
+
+    let new_rate_limiter_config = RateLimiterConfig {
+        window_duration: 50,
+        max_outflow: 0,
+    };
+
+    // case 1: try to update with a random user
+    let res = lending_market
+        .update_reserve_config(
+            &mut test,
+            &rando,
+            &wsol_reserve,
+            new_reserve_config,
+            new_rate_limiter_config,
+            None,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        res,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidSigner as u32)
+        )
+    );
+
+    // case 2: try to update without signing
+    let err = test
+        .process_transaction(
+            &[malicious_update_reserve_config(
+                solend_program::id(),
+                new_reserve_config,
+                new_rate_limiter_config,
+                wsol_reserve.pubkey,
+                lending_market.pubkey,
+                lending_market_owner.keypair.pubkey(),
+                test.mints
+                    .get(&wsol_mint::id())
+                    .unwrap()
+                    .unwrap()
+                    .pyth_product_pubkey,
+                wsol_reserve.account.liquidity.pyth_oracle_pubkey,
+                wsol_reserve.account.liquidity.switchboard_oracle_pubkey,
+            )],
+            None,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidSigner as u32)
+        )
+    );
+}
+
+/// Creates an Malicious 'UpdateReserveConfig' instruction (no signer needed)
+#[allow(clippy::too_many_arguments)]
+pub fn malicious_update_reserve_config(
+    program_id: Pubkey,
+    config: ReserveConfig,
+    rate_limiter_config: RateLimiterConfig,
+    reserve_pubkey: Pubkey,
+    lending_market_pubkey: Pubkey,
+    lending_market_owner_pubkey: Pubkey,
+    pyth_product_pubkey: Pubkey,
+    pyth_price_pubkey: Pubkey,
+    switchboard_feed_pubkey: Pubkey,
+) -> Instruction {
+    let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
+        &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
+        &program_id,
+    );
+    let accounts = vec![
+        AccountMeta::new(reserve_pubkey, false),
+        AccountMeta::new_readonly(lending_market_pubkey, false),
+        AccountMeta::new_readonly(lending_market_authority_pubkey, false),
+        AccountMeta::new_readonly(lending_market_owner_pubkey, false),
+        AccountMeta::new_readonly(pyth_product_pubkey, false),
+        AccountMeta::new_readonly(pyth_price_pubkey, false),
+        AccountMeta::new_readonly(switchboard_feed_pubkey, false),
+    ];
+    Instruction {
+        program_id,
+        accounts,
+        data: LendingInstruction::UpdateReserveConfig {
+            config,
+            rate_limiter_config,
+        }
+        .pack(),
+    }
+}

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -509,7 +509,7 @@ impl LendingInstruction {
                         window_duration,
                         max_outflow,
                     },
-                    risk_authority
+                    risk_authority,
                 }
             }
             2 => {
@@ -743,7 +743,7 @@ impl LendingInstruction {
             Self::SetLendingMarketOwnerAndConfig {
                 new_owner,
                 rate_limiter_config: config,
-                risk_authority
+                risk_authority,
             } => {
                 buf.push(1);
                 buf.extend_from_slice(new_owner.as_ref());

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -48,6 +48,8 @@ pub enum LendingInstruction {
         new_owner: Pubkey,
         /// The new config
         rate_limiter_config: RateLimiterConfig,
+        /// The risk authority
+        risk_authority: Pubkey,
     },
 
     // 2
@@ -499,13 +501,15 @@ impl LendingInstruction {
             1 => {
                 let (new_owner, rest) = Self::unpack_pubkey(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
-                let (max_outflow, _rest) = Self::unpack_u64(rest)?;
+                let (max_outflow, rest) = Self::unpack_u64(rest)?;
+                let (risk_authority, _rest) = Self::unpack_pubkey(rest)?;
                 Self::SetLendingMarketOwnerAndConfig {
                     new_owner,
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
                         max_outflow,
                     },
+                    risk_authority
                 }
             }
             2 => {
@@ -739,11 +743,13 @@ impl LendingInstruction {
             Self::SetLendingMarketOwnerAndConfig {
                 new_owner,
                 rate_limiter_config: config,
+                risk_authority
             } => {
                 buf.push(1);
                 buf.extend_from_slice(new_owner.as_ref());
                 buf.extend_from_slice(&config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&config.max_outflow.to_le_bytes());
+                buf.extend_from_slice(risk_authority.as_ref());
             }
             Self::InitReserve {
                 liquidity_amount,
@@ -926,6 +932,7 @@ pub fn set_lending_market_owner_and_config(
     lending_market_owner: Pubkey,
     new_owner: Pubkey,
     rate_limiter_config: RateLimiterConfig,
+    risk_authority: Pubkey,
 ) -> Instruction {
     Instruction {
         program_id,
@@ -936,6 +943,7 @@ pub fn set_lending_market_owner_and_config(
         data: LendingInstruction::SetLendingMarketOwnerAndConfig {
             new_owner,
             rate_limiter_config,
+            risk_authority,
         }
         .pack(),
     }
@@ -1606,6 +1614,7 @@ mod test {
                         window_duration: rng.gen::<u64>(),
                         max_outflow: rng.gen::<u64>(),
                     },
+                    risk_authority: Pubkey::new_unique(),
                 };
 
                 let packed = instruction.pack();


### PR DESCRIPTION
Description:

Solend V2 introduces an additional risk authority that has the ability to adjust risk parameters, only if the change results in the protocol being safer (e.g. lowering borrow limits). This allows different authorities to be custodied according to their sensitivity, rather than having just one authority responsible for everything. In particular, this risk authority has low enough sensitivity that it can be stored on a server to allow for automated configuration, for example automatically pausing borrows when anomalies are detected.

Risks:
I'm changing the update_reserve_config instruction which poses some security risks, so I wrote some tests to make sure only the correct keypairs can successfully call this instruction.