### PR TITLE
Onchain metadata

### DIFF
--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -19,6 +19,7 @@ solend-sdk = { path = "../sdk" }
 static_assertions = "1.1.0"
 switchboard-program = "0.2.0"
 switchboard-v2 = "0.1.3"
+bytemuck = "1.5.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -180,10 +180,10 @@ pub fn process_instruction(
             msg!("Instruction: Forgive Debt");
             process_forgive_debt(program_id, liquidity_amount, accounts)
         }
-        LendingInstruction::UpdateMetadata => {
+        LendingInstruction::UpdateMarketMetadata => {
             msg!("Instruction: Update Metadata");
             let metadata = LendingMarketMetadata::new_from_bytes(input)?;
-            process_update_metadata(program_id, metadata, accounts)
+            process_update_market_metadata(program_id, metadata, accounts)
         }
     }
 }
@@ -2743,7 +2743,7 @@ fn assert_rent_exempt(rent: &Rent, account_info: &AccountInfo) -> ProgramResult 
     }
 }
 
-fn process_update_metadata(
+fn process_update_market_metadata(
     program_id: &Pubkey,
     metadata: &LendingMarketMetadata,
     accounts: &[AccountInfo],
@@ -2796,6 +2796,11 @@ fn process_update_metadata(
             &[lending_market_owner_info.clone(), metadata_info.clone()],
             &[&[lending_market_info.key.as_ref(), br"MetaData", &[bump_seed]]],
         )?;
+    }
+
+    if metadata_info.owner != program_id {
+        msg!("Metadata provided is not owned by the lending program");
+        return Err(LendingError::InvalidAccountOwner.into());
     }
 
     let mut metadata_account_data = metadata_info.try_borrow_mut_data()?;

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -14,14 +14,7 @@ use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
 };
-use solend_program::{
-    instruction::{
-        borrow_obligation_liquidity, deposit_reserve_liquidity_and_obligation_collateral,
-        init_obligation, liquidate_obligation, refresh_obligation, refresh_reserve,
-        withdraw_obligation_collateral_and_redeem_reserve_collateral,
-    },
-    state::{Obligation, ReserveConfig, ReserveFees, ReserveType},
-};
+use solend_program::state::{ReserveConfig, ReserveFees, ReserveType};
 
 use spl_token::state::Mint;
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -131,6 +131,9 @@ impl SolendProgramTest {
 
         transaction.sign(&all_signers, self.context.last_blockhash);
 
+        let serialized = bincode::serialize(&transaction).unwrap();
+        assert!(serialized.len() <= 1232);
+
         self.context
             .banks_client
             .process_transaction(transaction)

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1219,7 +1219,7 @@ impl Info<LendingMarket> {
         lending_market_owner: &User,
         metadata: LendingMarketMetadata,
     ) -> Result<(), BanksClientError> {
-        let instructions = [update_metadata(
+        let instructions = [update_market_metadata(
             solend_program::id(),
             metadata,
             self.pubkey,

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1,3 +1,6 @@
+use solend_sdk::state::*;
+use solend_sdk::instruction::*;
+
 use super::{
     flash_loan_proxy::proxy_program,
     mock_pyth::{init_switchboard, set_switchboard_price},
@@ -1193,6 +1196,24 @@ impl Info<LendingMarket> {
         test.process_transaction(&instructions, Some(&[&lending_market_owner.keypair]))
             .await
     }
+
+    pub async fn update_metadata(
+        &self,
+        test: &mut SolendProgramTest,
+        lending_market_owner: &User,
+        params: InitLendingMarketMetadataParams
+    ) -> Result<(), BanksClientError> {
+        let instructions = [update_metadata(
+            solend_program::id(),
+            params,
+            self.pubkey,
+            lending_market_owner.keypair.pubkey(),
+        )];
+
+        test.process_transaction(&instructions, Some(&[&lending_market_owner.keypair]))
+            .await
+    }
+
 }
 
 /// Track token balance changes across transactions.

--- a/token-lending/program/tests/update_metadata.rs
+++ b/token-lending/program/tests/update_metadata.rs
@@ -3,6 +3,7 @@
 mod helpers;
 
 use crate::solend_program_test::custom_scenario;
+use solend_sdk::NULL_PUBKEY;
 
 use helpers::*;
 
@@ -39,6 +40,7 @@ async fn test_success() {
                 market_name: [2u8; MARKET_NAME_SIZE],
                 market_description: [3u8; MARKET_DESCRIPTION_SIZE],
                 market_image_url: [4u8; MARKET_IMAGE_URL_SIZE],
+                lookup_tables: [NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY],
                 padding: [5u8; PADDING_SIZE],
             },
         )
@@ -65,6 +67,7 @@ async fn test_success() {
             market_name: [2u8; MARKET_NAME_SIZE],
             market_description: [3u8; MARKET_DESCRIPTION_SIZE],
             market_image_url: [4u8; MARKET_IMAGE_URL_SIZE],
+            lookup_tables: [NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY,],
             padding: [5u8; PADDING_SIZE],
         }
     );
@@ -78,6 +81,7 @@ async fn test_success() {
                 market_name: [6u8; MARKET_NAME_SIZE],
                 market_description: [7u8; MARKET_DESCRIPTION_SIZE],
                 market_image_url: [8u8; MARKET_IMAGE_URL_SIZE],
+                lookup_tables: [NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY],
                 padding: [9u8; PADDING_SIZE],
             },
         )
@@ -100,6 +104,7 @@ async fn test_success() {
             market_name: [6u8; MARKET_NAME_SIZE],
             market_description: [7u8; MARKET_DESCRIPTION_SIZE],
             market_image_url: [8u8; MARKET_IMAGE_URL_SIZE],
+            lookup_tables: [NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY, NULL_PUBKEY],
             padding: [9u8; PADDING_SIZE],
         }
     );

--- a/token-lending/program/tests/update_metadata.rs
+++ b/token-lending/program/tests/update_metadata.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use crate::solend_program_test::custom_scenario;
+use helpers::solend_program_test::{SolendProgramTest, User};
+use helpers::*;
+use mock_pyth::mock_pyth_program;
+use solana_program::instruction::InstructionError;
+use solana_program::pubkey::Pubkey;
+use solana_program::system_instruction::transfer;
+use solana_program_test::*;
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+use solend_program::instruction::init_lending_market;
+use solend_program::state::{
+    InitLendingMarketMetadataParams, LendingMarket, LendingMarketMetadata, RateLimiter,
+    MARKET_DESCRIPTION_SIZE, MARKET_IMAGE_URL_SIZE, PROGRAM_VERSION,
+};
+use solend_sdk::state::MARKET_NAME_SIZE;
+
+#[tokio::test]
+async fn test_success() {
+    let (mut test, lending_market, _reserves, _obligations, _users, lending_market_owner) =
+        custom_scenario(&[], &[]).await;
+
+    let instructions = [transfer(
+        &test.context.payer.pubkey(),
+        &lending_market_owner.keypair.pubkey(),
+        LAMPORTS_PER_SOL,
+    )];
+    test.process_transaction(&instructions, None).await.unwrap();
+
+    lending_market
+        .update_metadata(
+            &mut test,
+            &lending_market_owner,
+            InitLendingMarketMetadataParams {
+                bump_seed: 0, // gets filled in automatically
+                market_address: lending_market.pubkey,
+                market_name: [2u8; MARKET_NAME_SIZE],
+                market_description: [3u8; MARKET_DESCRIPTION_SIZE],
+                market_image_url: [4u8; MARKET_IMAGE_URL_SIZE],
+            },
+        )
+        .await
+        .unwrap();
+
+    let metadata_seeds = &[lending_market.pubkey.as_ref(), b"MetaData"];
+    let (metadata_key, _bump_seed) =
+        Pubkey::find_program_address(metadata_seeds, &solend_program::id());
+
+    let lending_market_metadata = test
+        .load_account::<LendingMarketMetadata>(metadata_key)
+        .await;
+
+    println!("{:#?}", lending_market_metadata);
+
+    lending_market
+        .update_metadata(
+            &mut test,
+            &lending_market_owner,
+            InitLendingMarketMetadataParams {
+                bump_seed: 0, // gets filled in automatically
+                market_address: lending_market.pubkey,
+                market_name: [5u8; MARKET_NAME_SIZE],
+                market_description: [6u8; MARKET_DESCRIPTION_SIZE],
+                market_image_url: [7u8; MARKET_IMAGE_URL_SIZE],
+            },
+        )
+        .await
+        .unwrap();
+
+    let lending_market_metadata = test
+        .load_account::<LendingMarketMetadata>(metadata_key)
+        .await;
+
+    println!("{:#?}", lending_market_metadata);
+}

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -487,7 +487,7 @@ pub enum LendingInstruction {
     },
 
     // 22
-    /// UpdateMetadata
+    /// UpdateMarketMetadata
     ///
     /// Accounts expected by this instruction:
     /// 0. `[]` Lending market account.
@@ -495,7 +495,7 @@ pub enum LendingInstruction {
     /// 2. `[writable]` Lending market metadata account.
     /// Must be a pda with seeds [lending_market, "MetaData"]
     /// 3. `[]` System program
-    UpdateMetadata,
+    UpdateMarketMetadata,
 }
 
 impl LendingInstruction {
@@ -692,7 +692,7 @@ impl LendingInstruction {
                 let (liquidity_amount, _rest) = Self::unpack_u64(rest)?;
                 Self::ForgiveDebt { liquidity_amount }
             }
-            22 => Self::UpdateMetadata,
+            22 => Self::UpdateMarketMetadata,
             _ => {
                 msg!("Instruction cannot be unpacked");
                 return Err(LendingError::InstructionUnpackError.into());
@@ -925,7 +925,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&liquidity_amount.to_le_bytes());
             }
             // special handling for this instruction, bc the instruction is too big to deserialize
-            Self::UpdateMetadata => {}
+            Self::UpdateMarketMetadata => {}
         }
         buf
     }
@@ -1617,8 +1617,8 @@ pub fn forgive_debt(
     }
 }
 
-/// Creates a `UpdateMetadata` instruction
-pub fn update_metadata(
+/// Creates a `UpdateMarketMetadata` instruction
+pub fn update_market_metadata(
     program_id: Pubkey,
     mut metadata: LendingMarketMetadata,
     lending_market_pubkey: Pubkey,

--- a/token-lending/sdk/src/state/lending_market_metadata.rs
+++ b/token-lending/sdk/src/state/lending_market_metadata.rs
@@ -1,125 +1,56 @@
 use super::*;
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use solana_program::{
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::{Pubkey, PUBKEY_BYTES},
-};
+
+use crate::error::LendingError;
+use bytemuck::checked::try_from_bytes;
+use bytemuck::{Pod, Zeroable};
+use solana_program::program_error::ProgramError;
+use static_assertions::{assert_eq_size, const_assert};
 
 /// market name size
 pub const MARKET_NAME_SIZE: usize = 50;
 
 /// market description size
-pub const MARKET_DESCRIPTION_SIZE: usize = 50;
+pub const MARKET_DESCRIPTION_SIZE: usize = 250;
 
 /// market image url size
-pub const MARKET_IMAGE_URL_SIZE: usize = 50;
+pub const MARKET_IMAGE_URL_SIZE: usize = 250;
+
+/// padding size
+pub const PADDING_SIZE: usize = 200;
 
 /// Lending market state
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
 pub struct LendingMarketMetadata {
-    /// Version of lending market metadata
-    pub version: u8,
-    /// Market address
-    pub market_address: Pubkey,
     /// Market name null padded
     pub market_name: [u8; MARKET_NAME_SIZE],
     /// Market description null padded
     pub market_description: [u8; MARKET_DESCRIPTION_SIZE],
     /// Market image url
     pub market_image_url: [u8; MARKET_IMAGE_URL_SIZE],
+    /// Padding
+    pub padding: [u8; PADDING_SIZE],
+    /// Bump seed
+    pub bump_seed: u8,
 }
 
 impl LendingMarketMetadata {
-    /// Create a new lending market metadata
-    pub fn new(params: InitLendingMarketMetadataParams) -> Self {
-        Self {
-            version: PROGRAM_VERSION,
-            market_address: params.market_address,
-            market_name: params.market_name,
-            market_description: params.market_description,
-            market_image_url: params.market_image_url,
-        }
-    }
-
-    /// Initialize a lending market metadata
-    pub fn init(&mut self, params: InitLendingMarketMetadataParams) {
-        self.version = PROGRAM_VERSION;
-        self.market_address = params.market_address;
-        self.market_name = params.market_name;
-        self.market_description = params.market_description;
-        self.market_image_url = params.market_image_url;
-    }
-}
-
-/// Initialize a lending market metadata
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct InitLendingMarketMetadataParams {
-    /// Bump seed for derived authority address
-    pub bump_seed: u8,
-    /// Market address
-    pub market_address: Pubkey,
-    /// Market name null padded
-    pub market_name: [u8; MARKET_NAME_SIZE],
-    /// Market description null padded
-    pub market_description: [u8; MARKET_DESCRIPTION_SIZE],
-    /// Market image url
-    pub market_image_url: [u8; MARKET_IMAGE_URL_SIZE],
-}
-
-impl Sealed for LendingMarketMetadata {}
-impl IsInitialized for LendingMarketMetadata {
-    fn is_initialized(&self) -> bool {
-        self.version != UNINITIALIZED_VERSION
-    }
-}
-
-const LENDING_MARKET_METADATA_LEN: usize =
-    1 + PUBKEY_BYTES + MARKET_NAME_SIZE + MARKET_DESCRIPTION_SIZE + MARKET_IMAGE_URL_SIZE + 1000;
-
-impl Pack for LendingMarketMetadata {
-    const LEN: usize = LENDING_MARKET_METADATA_LEN;
-
-    fn pack_into_slice(&self, output: &mut [u8]) {
-        let output = array_mut_ref![output, 0, LENDING_MARKET_METADATA_LEN];
-        #[allow(clippy::ptr_offset_with_cast)]
-        let (version, market_address, market_name, market_description, market_image_url, _padding) = mut_array_refs![
-            output,
-            1,
-            PUBKEY_BYTES,
-            MARKET_NAME_SIZE,
-            MARKET_DESCRIPTION_SIZE,
-            MARKET_IMAGE_URL_SIZE,
-            1000
-        ];
-
-        *version = self.version.to_le_bytes();
-        market_address.copy_from_slice(self.market_address.as_ref());
-        market_name.copy_from_slice(self.market_name.as_ref());
-        market_description.copy_from_slice(self.market_description.as_ref());
-        market_image_url.copy_from_slice(self.market_image_url.as_ref());
-    }
-
-    /// Unpacks a byte buffer into a [LendingMarketMetadataInfo](struct.LendingMarketMetadataInfo.html)
-    fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
-        let input = array_ref![input, 0, LENDING_MARKET_METADATA_LEN];
-        #[allow(clippy::ptr_offset_with_cast)]
-        let (version, market_address, market_name, market_description, market_image_url, _padding) = array_refs![
-            input,
-            1,
-            PUBKEY_BYTES,
-            MARKET_NAME_SIZE,
-            MARKET_DESCRIPTION_SIZE,
-            MARKET_IMAGE_URL_SIZE,
-            1000
-        ];
-
-        Ok(Self {
-            version: u8::from_le_bytes(*version),
-            market_address: Pubkey::new_from_array(*market_address),
-            market_name: *market_name,
-            market_description: *market_description,
-            market_image_url: *market_image_url,
+    /// Create a LendingMarketMetadata referernce from a slice
+    pub fn new_from_bytes(data: &[u8]) -> Result<&LendingMarketMetadata, ProgramError> {
+        try_from_bytes::<LendingMarketMetadata>(&data[1..]).map_err(|_| {
+            msg!("Failed to deserialize LendingMarketMetadata");
+            LendingError::InstructionUnpackError.into()
         })
     }
 }
+
+unsafe impl Zeroable for LendingMarketMetadata {}
+unsafe impl Pod for LendingMarketMetadata {}
+
+assert_eq_size!(
+    LendingMarketMetadata,
+    [u8; MARKET_NAME_SIZE + MARKET_DESCRIPTION_SIZE + MARKET_IMAGE_URL_SIZE + PADDING_SIZE + 1],
+);
+
+// transaction size limit check
+const_assert!(std::mem::size_of::<LendingMarketMetadata>() <= 800);

--- a/token-lending/sdk/src/state/lending_market_metadata.rs
+++ b/token-lending/sdk/src/state/lending_market_metadata.rs
@@ -11,7 +11,7 @@ use static_assertions::{assert_eq_size, const_assert};
 pub const MARKET_NAME_SIZE: usize = 50;
 
 /// market description size
-pub const MARKET_DESCRIPTION_SIZE: usize = 250;
+pub const MARKET_DESCRIPTION_SIZE: usize = 300;
 
 /// market image url size
 pub const MARKET_IMAGE_URL_SIZE: usize = 250;
@@ -23,6 +23,8 @@ pub const PADDING_SIZE: usize = 100;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct LendingMarketMetadata {
+    /// Bump seed
+    pub bump_seed: u8,
     /// Market name null padded
     pub market_name: [u8; MARKET_NAME_SIZE],
     /// Market description null padded
@@ -33,8 +35,6 @@ pub struct LendingMarketMetadata {
     pub lookup_tables: [Pubkey; 4],
     /// Padding
     pub padding: [u8; PADDING_SIZE],
-    /// Bump seed
-    pub bump_seed: u8,
 }
 
 impl LendingMarketMetadata {
@@ -61,4 +61,4 @@ assert_eq_size!(
 );
 
 // transaction size limit check
-const_assert!(std::mem::size_of::<LendingMarketMetadata>() <= 800);
+const_assert!(std::mem::size_of::<LendingMarketMetadata>() <= 850);

--- a/token-lending/sdk/src/state/lending_market_metadata.rs
+++ b/token-lending/sdk/src/state/lending_market_metadata.rs
@@ -1,0 +1,130 @@
+use super::*;
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_program::{
+    msg,
+    program_error::ProgramError,
+    program_pack::{IsInitialized, Pack, Sealed},
+    pubkey::{Pubkey, PUBKEY_BYTES},
+};
+
+/// Lending market state
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LendingMarketMetadata {
+    /// Version of lending market metadata
+    pub version: u8,
+    /// Market address
+    pub market_address: Pubkey,
+    /// Market name null padded
+    pub market_name: [u8; 50],
+    /// Market description null padded
+    pub market_description: [u8; 1000],
+    /// Market image url
+    pub market_image_url: [u8; 150],
+}
+
+impl LendingMarketMetadata {
+    /// Create a new lending market metadata
+    pub fn new(params: InitLendingMarketMetadataParams) -> Self {
+        let mut lending_market = Self::default();
+        Self::init(&mut lending_market, params);
+        lending_market
+    }
+
+    /// Initialize a lending market metadata
+    pub fn init(&mut self, params: InitLendingMarketMetadataParams) {
+        self.version = PROGRAM_VERSION;
+        self.market_address = params.market_address;
+        self.market_name = params.market_name;
+        self.market_description = params.market_description;
+        self.market_image_url = params.market_image_url;
+    }
+}
+
+/// Initialize a lending market metadata
+pub struct InitLendingMarketMetadataParams {
+    /// Bump seed for derived authority address
+    pub bump_seed: u8,
+    /// Market address
+    pub market_address: Pubkey,
+    /// Market name null padded
+    pub market_name: [u8; 50],
+    /// Market description null padded
+    pub market_description: [u8; 1000],
+    /// Market image url
+    pub market_image_url: [u8; 150],
+}
+
+impl Sealed for LendingMarketMetadata {}
+impl IsInitialized for LendingMarketMetadata {
+    fn is_initialized(&self) -> bool {
+        self.version != UNINITIALIZED_VERSION
+    }
+}
+
+const LENDING_MARKET_METADATA_LEN: usize = 290; // 1 + 1 + 32 + 50 + 1000 + 150 + 1000
+impl Pack for LendingMarketMetadata {
+    const LEN: usize = LENDING_MARKET_METADATA_LEN;
+
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        let output = array_mut_ref![output, 0, LENDING_MARKET_METADATA_LEN];
+        #[allow(clippy::ptr_offset_with_cast)]
+        let (
+            version,
+            market_address,
+            market_name,
+            market_description,
+            market_image_url,
+            _padding,
+        ) = mut_array_refs![
+            output,
+            1,
+            PUBKEY_BYTES,
+            50,
+            1000,
+            150,
+            1000,
+        ];
+
+        *version = self.version.to_le_bytes();
+        market_address.copy_from_slice(self.market_address.as_ref());
+        market_name.copy_from_slice(self.market_name.as_ref());
+        market_description.copy_from_slice(self.market_description.as_ref());
+        market_image_url.copy_from_slice(self.market_image_url.as_ref());
+    }
+
+    /// Unpacks a byte buffer into a [LendingMarketMetadataInfo](struct.LendingMarketMetadataInfo.html)
+    fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
+        let input = array_ref![input, 0, LENDING_MARKET_METADATA_LEN];
+        #[allow(clippy::ptr_offset_with_cast)]
+        let (
+            version,
+            market_address,
+            market_name,
+            market_description,
+            market_image_url,
+            _padding,
+        ) = array_refs![
+            input,
+            1,
+            PUBKEY_BYTES,
+            50,
+            1000,
+            150,
+            1000,
+        ];
+
+        let version = u8::from_le_bytes(*version);
+        if version > PROGRAM_VERSION {
+            msg!("Lending market metadata version does not match lending program version");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            version,
+            market_address:Pubkey::new_from_array(*market_address),
+            market_name: *market_name,
+            market_description: *market_description,
+            market_image_url: *market_image_url,
+        })
+    }
+}

--- a/token-lending/sdk/src/state/lending_market_metadata.rs
+++ b/token-lending/sdk/src/state/lending_market_metadata.rs
@@ -4,6 +4,7 @@ use crate::error::LendingError;
 use bytemuck::checked::try_from_bytes;
 use bytemuck::{Pod, Zeroable};
 use solana_program::program_error::ProgramError;
+use solana_program::pubkey::Pubkey;
 use static_assertions::{assert_eq_size, const_assert};
 
 /// market name size
@@ -16,7 +17,7 @@ pub const MARKET_DESCRIPTION_SIZE: usize = 250;
 pub const MARKET_IMAGE_URL_SIZE: usize = 250;
 
 /// padding size
-pub const PADDING_SIZE: usize = 200;
+pub const PADDING_SIZE: usize = 100;
 
 /// Lending market state
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -28,6 +29,8 @@ pub struct LendingMarketMetadata {
     pub market_description: [u8; MARKET_DESCRIPTION_SIZE],
     /// Market image url
     pub market_image_url: [u8; MARKET_IMAGE_URL_SIZE],
+    /// Lookup Tables
+    pub lookup_tables: [Pubkey; 4],
     /// Padding
     pub padding: [u8; PADDING_SIZE],
     /// Bump seed
@@ -49,7 +52,12 @@ unsafe impl Pod for LendingMarketMetadata {}
 
 assert_eq_size!(
     LendingMarketMetadata,
-    [u8; MARKET_NAME_SIZE + MARKET_DESCRIPTION_SIZE + MARKET_IMAGE_URL_SIZE + PADDING_SIZE + 1],
+    [u8; MARKET_NAME_SIZE
+        + MARKET_DESCRIPTION_SIZE
+        + MARKET_IMAGE_URL_SIZE
+        + 4 * 32
+        + PADDING_SIZE
+        + 1],
 );
 
 // transaction size limit check

--- a/token-lending/sdk/src/state/mod.rs
+++ b/token-lending/sdk/src/state/mod.rs
@@ -5,12 +5,14 @@ mod lending_market;
 mod obligation;
 mod rate_limiter;
 mod reserve;
+mod lending_market_metadata;
 
 pub use last_update::*;
 pub use lending_market::*;
 pub use obligation::*;
 pub use rate_limiter::*;
 pub use reserve::*;
+pub use lending_market_metadata::*;
 
 use crate::math::{Decimal, WAD};
 use solana_program::{msg, program_error::ProgramError};

--- a/token-lending/sdk/src/state/mod.rs
+++ b/token-lending/sdk/src/state/mod.rs
@@ -2,17 +2,17 @@
 
 mod last_update;
 mod lending_market;
+mod lending_market_metadata;
 mod obligation;
 mod rate_limiter;
 mod reserve;
-mod lending_market_metadata;
 
 pub use last_update::*;
 pub use lending_market::*;
+pub use lending_market_metadata::*;
 pub use obligation::*;
 pub use rate_limiter::*;
 pub use reserve::*;
-pub use lending_market_metadata::*;
 
 use crate::math::{Decimal, WAD};
 use solana_program::{msg, program_error::ProgramError};


### PR DESCRIPTION
the metadata account is stored as a pda. this is a fairly low risk change.

> Solend V1 serves metadata from a backend, creating a centralized dependency to fetch things like pool names, descriptions, and lookup tables. Solend V2 stores metadata on-chain, reducing Solend’s dependency on a backend and improving decentralization.

Probably will hold off on merging this until the FE work is done, in case we're missing some fields