### PR TITLE
5ph can change all fee configs + fix oracle check bug

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2280,8 +2280,7 @@ fn process_update_reserve_config(
             reserve.liquidity.switchboard_oracle_pubkey = *switchboard_feed_info.key;
         }
         if reserve.liquidity.switchboard_oracle_pubkey == solend_program::NULL_PUBKEY
-            && (*pyth_price_info.key == solend_program::NULL_PUBKEY
-                || *pyth_product_info.key == solend_program::NULL_PUBKEY)
+            && reserve.liquidity.pyth_oracle_pubkey == solend_program::NULL_PUBKEY
         {
             msg!("At least one price oracle must have a non-null pubkey");
             return Err(LendingError::InvalidOracleConfig.into());
@@ -2303,6 +2302,12 @@ fn process_update_reserve_config(
         if config.deposit_limit < reserve.config.deposit_limit {
             reserve.config.deposit_limit = config.deposit_limit;
         }
+    } else if *signer_info.key == solend_market_owner::id()
+        && lending_market.owner != solend_market_owner::id()
+    // the second check is technically unnecessary but it's here in case future changes reorder the
+    // branches in this function
+    {
+        reserve.config.fees = config.fees;
     } else {
         msg!("Signer must be the Lending market owner or risk authority");
         return Err(LendingError::InvalidSigner.into());

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2235,12 +2235,8 @@ fn process_update_reserve_config(
             msg!("permissionless markets can't edit fee receiver");
             return Err(LendingError::InvalidConfig.into());
         }
-        if reserve.config.fees.flash_loan_fee_wad != config.fees.flash_loan_fee_wad {
-            msg!("permissionless markets can't edit flash loan fees");
-            return Err(LendingError::InvalidConfig.into());
-        }
-        if reserve.config.fees.host_fee_percentage != config.fees.host_fee_percentage {
-            msg!("permissionless markets can't edit host fee percentage");
+        if reserve.config.fees != config.fees {
+            msg!("permissionless markets can't edit fee configs!");
             return Err(LendingError::InvalidConfig.into());
         }
     }
@@ -2303,11 +2299,13 @@ fn process_update_reserve_config(
             reserve.config.deposit_limit = config.deposit_limit;
         }
     } else if *signer_info.key == solend_market_owner::id()
-        && lending_market.owner != solend_market_owner::id()
-    // the second check is technically unnecessary but it's here in case future changes reorder the
-    // branches in this function
+    // 5ph has the ability to change the
+    // fees on permissionless markets
     {
         reserve.config.fees = config.fees;
+        reserve.config.protocol_liquidation_fee = config.protocol_liquidation_fee;
+        reserve.config.protocol_take_rate = config.protocol_take_rate;
+        reserve.config.fee_receiver = config.fee_receiver;
     } else {
         msg!("Signer must be the Lending market owner or risk authority");
         return Err(LendingError::InvalidSigner.into());


### PR DESCRIPTION
1. 5ph needs to be able to change fee configs in permissionless markets
2. there's currently a bug where in order to update a reserve with a null switchboard key, you _always_ have to pass in the pyth product key. this change fixes that so you don't have to pass in the pyth product key anymore. 