### PR TITLE
oracle price multiplier

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1141,7 +1141,7 @@ fn main() {
 
             let added_borrow_weight_bps = value_of(arg_matches, "added_borrow_weight_bps").unwrap();
             let reserve_type = value_of(arg_matches, "reserve_type").unwrap();
-            let added_price_weight_bps = value_of(arg_matches, "added_price_weight_bps").unwrap();
+            let scaled_price_offset_bps = value_of(arg_matches, "scaled_price_offset_bps").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -1195,7 +1195,7 @@ fn main() {
                     protocol_take_rate,
                     added_borrow_weight_bps,
                     reserve_type,
-                    added_price_weight_bps,
+                    scaled_price_offset_bps,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1141,6 +1141,7 @@ fn main() {
 
             let added_borrow_weight_bps = value_of(arg_matches, "added_borrow_weight_bps").unwrap();
             let reserve_type = value_of(arg_matches, "reserve_type").unwrap();
+            let added_price_weight_bps = value_of(arg_matches, "added_price_weight_bps").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -1194,6 +1195,7 @@ fn main() {
                     protocol_take_rate,
                     added_borrow_weight_bps,
                     reserve_type,
+                    added_price_weight_bps,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -511,11 +511,11 @@ fn _refresh_reserve<'a>(
     let (market_price, smoothed_market_price) =
         get_price(switchboard_feed_info, pyth_price_info, clock)?;
 
-    reserve.liquidity.market_price = market_price.try_mul(reserve.price_weight())?;
+    reserve.liquidity.market_price = market_price.try_mul(reserve.price_scale())?;
 
     if let Some(smoothed_market_price) = smoothed_market_price {
         reserve.liquidity.smoothed_market_price =
-            smoothed_market_price.try_mul(reserve.price_weight())?;
+            smoothed_market_price.try_mul(reserve.price_scale())?;
     }
 
     // currently there's no way to support two prices without a pyth oracle. So if a reserve

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -511,10 +511,11 @@ fn _refresh_reserve<'a>(
     let (market_price, smoothed_market_price) =
         get_price(switchboard_feed_info, pyth_price_info, clock)?;
 
-    reserve.liquidity.market_price = market_price;
+    reserve.liquidity.market_price = market_price.try_mul(reserve.price_weight())?;
 
     if let Some(smoothed_market_price) = smoothed_market_price {
-        reserve.liquidity.smoothed_market_price = smoothed_market_price;
+        reserve.liquidity.smoothed_market_price =
+            smoothed_market_price.try_mul(reserve.price_weight())?;
     }
 
     // currently there's no way to support two prices without a pyth oracle. So if a reserve

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -52,6 +52,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         protocol_take_rate: 0,
         added_borrow_weight_bps: 0,
         reserve_type: ReserveType::Regular,
+        added_price_weight_bps: 0,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -52,7 +52,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         protocol_take_rate: 0,
         added_borrow_weight_bps: 0,
         reserve_type: ReserveType::Regular,
-        added_price_weight_bps: 0,
+        scaled_price_offset_bps: 0,
     }
 }
 

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -2,11 +2,13 @@
 
 mod helpers;
 
+use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::setup_world;
 use crate::solend_program_test::BalanceChecker;
 use crate::solend_program_test::Info;
 use crate::solend_program_test::Oracle;
 use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
 use crate::solend_program_test::SolendProgramTest;
 use crate::solend_program_test::SwitchboardPriceArgs;
 use crate::solend_program_test::User;
@@ -351,5 +353,57 @@ async fn test_success_only_switchboard_reserve() {
     assert_eq!(
         wsol_reserve_post.account.liquidity.smoothed_market_price,
         Decimal::from(8u64)
+    );
+}
+
+#[tokio::test]
+async fn test_use_price_weight() {
+    let (mut test, lending_market, reserves, _obligations, _users, _) = custom_scenario(
+        &[ReserveArgs {
+            mint: wsol_mint::id(),
+            config: ReserveConfig {
+                added_price_weight_bps: 5_000,
+                ..test_reserve_config()
+            },
+            liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+            price: PriceArgs {
+                price: 10,
+                conf: 0,
+                expo: 0,
+                ema_price: 10,
+                ema_conf: 0,
+            },
+        }],
+        &[],
+    )
+    .await;
+
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 10,
+            conf: 0,
+            expo: 0,
+            ema_price: 12,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .refresh_reserve(&mut test, &reserves[0])
+        .await
+        .unwrap();
+
+    let wsol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        wsol_reserve.account.liquidity.market_price,
+        Decimal::from(15u64)
+    );
+    assert_eq!(
+        wsol_reserve.account.liquidity.smoothed_market_price,
+        Decimal::from(18u64)
     );
 }

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -363,7 +363,7 @@ async fn test_use_price_weight() {
             &[ReserveArgs {
                 mint: wsol_mint::id(),
                 config: ReserveConfig {
-                    added_price_weight_bps: 2_000,
+                    scaled_price_offset_bps: 2_000,
                     ..test_reserve_config()
                 },
                 liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
@@ -416,7 +416,7 @@ async fn test_use_price_weight() {
             &lending_market_owner,
             &wsol_reserve,
             ReserveConfig {
-                added_price_weight_bps: -2_000,
+                scaled_price_offset_bps: -2_000,
                 ..wsol_reserve.account.config
             },
             wsol_reserve.account.rate_limiter.config,

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -358,25 +358,26 @@ async fn test_success_only_switchboard_reserve() {
 
 #[tokio::test]
 async fn test_use_price_weight() {
-    let (mut test, lending_market, reserves, _obligations, _users, _) = custom_scenario(
-        &[ReserveArgs {
-            mint: wsol_mint::id(),
-            config: ReserveConfig {
-                added_price_weight_bps: 5_000,
-                ..test_reserve_config()
-            },
-            liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
-            price: PriceArgs {
-                price: 10,
-                conf: 0,
-                expo: 0,
-                ema_price: 10,
-                ema_conf: 0,
-            },
-        }],
-        &[],
-    )
-    .await;
+    let (mut test, lending_market, reserves, _obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    added_price_weight_bps: 2_000,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            }],
+            &[],
+        )
+        .await;
 
     test.set_price(
         &wsol_mint::id(),
@@ -384,7 +385,7 @@ async fn test_use_price_weight() {
             price: 10,
             conf: 0,
             expo: 0,
-            ema_price: 12,
+            ema_price: 20,
             ema_conf: 0,
         },
     )
@@ -400,10 +401,44 @@ async fn test_use_price_weight() {
     let wsol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
     assert_eq!(
         wsol_reserve.account.liquidity.market_price,
-        Decimal::from(15u64)
+        Decimal::from(12u64)
     );
     assert_eq!(
         wsol_reserve.account.liquidity.smoothed_market_price,
-        Decimal::from(18u64)
+        Decimal::from(24u64)
+    );
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &wsol_reserve,
+            ReserveConfig {
+                added_price_weight_bps: -2_000,
+                ..wsol_reserve.account.config
+            },
+            wsol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .refresh_reserve(&mut test, &reserves[0])
+        .await
+        .unwrap();
+
+    let wsol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        wsol_reserve.account.liquidity.market_price,
+        Decimal::from(8u64)
+    );
+    assert_eq!(
+        wsol_reserve.account.liquidity.smoothed_market_price,
+        Decimal::from(16u64)
     );
 }

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -561,7 +561,8 @@ impl LendingInstruction {
                 let (added_borrow_weight_bps, rest) = Self::unpack_u64(rest)?;
                 let (asset_type, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_bonus, rest) = Self::unpack_u8(rest)?;
-                let (max_liquidation_threshold, _rest) = Self::unpack_u8(rest)?;
+                let (max_liquidation_threshold, rest) = Self::unpack_u8(rest)?;
+                let (added_price_weight_bps, _rest) = Self::unpack_u64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -588,6 +589,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps,
                         reserve_type: ReserveType::from_u8(asset_type).unwrap(),
+                        added_price_weight_bps,
                     },
                 }
             }
@@ -656,6 +658,7 @@ impl LendingInstruction {
                 let (asset_type, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_bonus, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_threshold, rest) = Self::unpack_u8(rest)?;
+                let (added_price_weight_bps, rest) = Self::unpack_u64(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
 
@@ -684,6 +687,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps,
                         reserve_type: ReserveType::from_u8(asset_type).unwrap(),
+                        added_price_weight_bps,
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -833,6 +837,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps: borrow_weight_bps,
                         reserve_type: asset_type,
+                        added_price_weight_bps,
                     },
             } => {
                 buf.push(2);
@@ -858,6 +863,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&(asset_type as u8).to_le_bytes());
                 buf.extend_from_slice(&max_liquidation_bonus.to_le_bytes());
                 buf.extend_from_slice(&max_liquidation_threshold.to_le_bytes());
+                buf.extend_from_slice(&added_price_weight_bps.to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -934,6 +940,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&(config.reserve_type as u8).to_le_bytes());
                 buf.extend_from_slice(&config.max_liquidation_bonus.to_le_bytes());
                 buf.extend_from_slice(&config.max_liquidation_threshold.to_le_bytes());
+                buf.extend_from_slice(&config.added_price_weight_bps.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }
@@ -1757,6 +1764,7 @@ mod test {
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
                         reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        added_price_weight_bps: rng.gen::<u64>(),
                     },
                 };
 
@@ -1917,6 +1925,7 @@ mod test {
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
                         reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
+                        added_price_weight_bps: rng.gen::<u64>(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration: rng.gen::<u64>(),

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -562,7 +562,7 @@ impl LendingInstruction {
                 let (asset_type, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_bonus, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_threshold, rest) = Self::unpack_u8(rest)?;
-                let (added_price_weight_bps, _rest) = Self::unpack_i64(rest)?;
+                let (scaled_price_offset_bps, _rest) = Self::unpack_i64(rest)?;
                 Self::InitReserve {
                     liquidity_amount,
                     config: ReserveConfig {
@@ -589,7 +589,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps,
                         reserve_type: ReserveType::from_u8(asset_type).unwrap(),
-                        added_price_weight_bps,
+                        scaled_price_offset_bps,
                     },
                 }
             }
@@ -658,7 +658,7 @@ impl LendingInstruction {
                 let (asset_type, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_bonus, rest) = Self::unpack_u8(rest)?;
                 let (max_liquidation_threshold, rest) = Self::unpack_u8(rest)?;
-                let (added_price_weight_bps, rest) = Self::unpack_i64(rest)?;
+                let (scaled_price_offset_bps, rest) = Self::unpack_i64(rest)?;
                 let (window_duration, rest) = Self::unpack_u64(rest)?;
                 let (max_outflow, _rest) = Self::unpack_u64(rest)?;
 
@@ -687,7 +687,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps,
                         reserve_type: ReserveType::from_u8(asset_type).unwrap(),
-                        added_price_weight_bps,
+                        scaled_price_offset_bps,
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration,
@@ -851,7 +851,7 @@ impl LendingInstruction {
                         protocol_take_rate,
                         added_borrow_weight_bps: borrow_weight_bps,
                         reserve_type: asset_type,
-                        added_price_weight_bps,
+                        scaled_price_offset_bps,
                     },
             } => {
                 buf.push(2);
@@ -877,7 +877,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&(asset_type as u8).to_le_bytes());
                 buf.extend_from_slice(&max_liquidation_bonus.to_le_bytes());
                 buf.extend_from_slice(&max_liquidation_threshold.to_le_bytes());
-                buf.extend_from_slice(&added_price_weight_bps.to_le_bytes());
+                buf.extend_from_slice(&scaled_price_offset_bps.to_le_bytes());
             }
             Self::RefreshReserve => {
                 buf.push(3);
@@ -954,7 +954,7 @@ impl LendingInstruction {
                 buf.extend_from_slice(&(config.reserve_type as u8).to_le_bytes());
                 buf.extend_from_slice(&config.max_liquidation_bonus.to_le_bytes());
                 buf.extend_from_slice(&config.max_liquidation_threshold.to_le_bytes());
-                buf.extend_from_slice(&config.added_price_weight_bps.to_le_bytes());
+                buf.extend_from_slice(&config.scaled_price_offset_bps.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.window_duration.to_le_bytes());
                 buf.extend_from_slice(&rate_limiter_config.max_outflow.to_le_bytes());
             }
@@ -1778,7 +1778,7 @@ mod test {
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
                         reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
-                        added_price_weight_bps: rng.gen(),
+                        scaled_price_offset_bps: rng.gen(),
                     },
                 };
 
@@ -1939,7 +1939,7 @@ mod test {
                         protocol_take_rate: rng.gen::<u8>(),
                         added_borrow_weight_bps: rng.gen::<u64>(),
                         reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
-                        added_price_weight_bps: rng.gen(),
+                        scaled_price_offset_bps: rng.gen(),
                     },
                     rate_limiter_config: RateLimiterConfig {
                         window_duration: rng.gen::<u64>(),


### PR DESCRIPTION
For staked sol reserves, we don't want to use the pyth oracles because they have been historically unreliable. Instead, we want to use the sol price oracle but multiply the price by some constant. This constant will be set to roughly the staked sol / sol ratio on-chain but slightly discounted to account for depegs. 