### PR TITLE
Optional, extra oracle on reserve

### DIFF
--- a/token-lending/cli/src/lending_state.rs
+++ b/token-lending/cli/src/lending_state.rs
@@ -75,7 +75,7 @@ impl SolendState {
                 *pubkey,
                 reserve.liquidity.pyth_oracle_pubkey,
                 reserve.liquidity.switchboard_oracle_pubkey,
-                reserve.config.extra_oracle_pubkey
+                reserve.config.extra_oracle_pubkey,
             )
         }));
 

--- a/token-lending/cli/src/lending_state.rs
+++ b/token-lending/cli/src/lending_state.rs
@@ -75,6 +75,7 @@ impl SolendState {
                 *pubkey,
                 reserve.liquidity.pyth_oracle_pubkey,
                 reserve.liquidity.switchboard_oracle_pubkey,
+                reserve.config.extra_oracle_pubkey
             )
         }));
 

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1142,6 +1142,7 @@ fn main() {
             let added_borrow_weight_bps = value_of(arg_matches, "added_borrow_weight_bps").unwrap();
             let reserve_type = value_of(arg_matches, "reserve_type").unwrap();
             let scaled_price_offset_bps = value_of(arg_matches, "scaled_price_offset_bps").unwrap();
+            let extra_oracle_pubkey = pubkey_of(arg_matches, "extra_oracle_pubkey").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -1196,6 +1197,7 @@ fn main() {
                     added_borrow_weight_bps,
                     reserve_type,
                     scaled_price_offset_bps,
+                    extra_oracle_pubkey: Some(extra_oracle_pubkey),
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1546,7 +1546,7 @@ fn command_liquidate_obligation(
             *pubkey,
             reserve.liquidity.pyth_oracle_pubkey,
             reserve.liquidity.switchboard_oracle_pubkey,
-            reserve.config.extra_oracle_pubkey
+            reserve.config.extra_oracle_pubkey,
         )
     }));
 

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1546,6 +1546,7 @@ fn command_liquidate_obligation(
             *pubkey,
             reserve.liquidity.pyth_oracle_pubkey,
             reserve.liquidity.switchboard_oracle_pubkey,
+            reserve.config.extra_oracle_pubkey
         )
     }));
 

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -577,14 +577,12 @@ fn _refresh_reserve<'a>(
                     return Err(LendingError::InvalidAccountInput.into());
                 }
 
-                let market_price = match get_oracle_type(extra_oracle_account_info)? {
-                    OracleType::Pyth => get_pyth_price(extra_oracle_account_info, clock)?.0,
+                match get_oracle_type(extra_oracle_account_info)? {
+                    OracleType::Pyth => Some(get_pyth_price(extra_oracle_account_info, clock)?.0),
                     OracleType::Switchboard => {
-                        get_switchboard_price_v2(extra_oracle_account_info, clock)?
+                        Some(get_switchboard_price_v2(extra_oracle_account_info, clock)?)
                     }
-                };
-
-                Some(market_price.try_mul(reserve.price_scale())?)
+                }
             }
             None => {
                 msg!("Reserve extra oracle account info missing");

--- a/token-lending/program/tests/helpers/mock_pyth.rs
+++ b/token-lending/program/tests/helpers/mock_pyth.rs
@@ -34,7 +34,7 @@ pub enum MockPythInstruction {
         expo: i32,
         ema_price: i64,
         ema_conf: u64,
-    }
+    },
 }
 
 pub fn process_instruction(

--- a/token-lending/program/tests/helpers/mock_pyth.rs
+++ b/token-lending/program/tests/helpers/mock_pyth.rs
@@ -12,18 +12,12 @@ use solana_program::{
     pubkey::Pubkey,
     sysvar::Sysvar,
 };
-use std::cell::RefMut;
-use switchboard_v2::{AggregatorAccountData, SwitchboardDecimal};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use spl_token::solana_program::{account_info::next_account_info, program_error::ProgramError};
 use thiserror::Error;
 
 use super::{load_mut, QUOTE_CURRENCY};
-
-pub mod mock_pyth_program {
-    solana_program::declare_id!("SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f");
-}
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub enum MockPythInstruction {
@@ -40,15 +34,7 @@ pub enum MockPythInstruction {
         expo: i32,
         ema_price: i64,
         ema_conf: u64,
-    },
-
-    /// Accounts:
-    /// 0: AggregatorAccount
-    InitSwitchboard,
-
-    /// Accounts:
-    /// 0: AggregatorAccount
-    SetSwitchboardPrice { price: i64, expo: i32 },
+    }
 }
 
 pub fn process_instruction(
@@ -152,37 +138,6 @@ impl Processor {
 
                 Ok(())
             }
-            MockPythInstruction::InitSwitchboard => {
-                msg!("Mock Pyth: Init Switchboard");
-                let switchboard_feed = next_account_info(account_info_iter)?;
-                let mut data = switchboard_feed.try_borrow_mut_data()?;
-
-                let discriminator = [217, 230, 65, 101, 201, 162, 27, 125];
-                data[0..8].copy_from_slice(&discriminator);
-                Ok(())
-            }
-            MockPythInstruction::SetSwitchboardPrice { price, expo } => {
-                msg!("Mock Pyth: Set Switchboard price");
-                let switchboard_feed = next_account_info(account_info_iter)?;
-                let data = switchboard_feed.try_borrow_mut_data()?;
-
-                let mut aggregator_account: RefMut<AggregatorAccountData> =
-                    RefMut::map(data, |data| {
-                        bytemuck::from_bytes_mut(
-                            &mut data[8..std::mem::size_of::<AggregatorAccountData>() + 8],
-                        )
-                    });
-
-                aggregator_account.min_oracle_results = 1;
-                aggregator_account.latest_confirmed_round.num_success = 1;
-                aggregator_account.latest_confirmed_round.result = SwitchboardDecimal {
-                    mantissa: price as i128,
-                    scale: expo as u32,
-                };
-                aggregator_account.latest_confirmed_round.round_open_slot = Clock::get()?.slot;
-
-                Ok(())
-            }
         }
     }
 }
@@ -241,31 +196,6 @@ pub fn set_price(
     Instruction {
         program_id,
         accounts: vec![AccountMeta::new(price_account_pubkey, false)],
-        data,
-    }
-}
-
-pub fn set_switchboard_price(
-    program_id: Pubkey,
-    switchboard_feed: Pubkey,
-    price: i64,
-    expo: i32,
-) -> Instruction {
-    let data = MockPythInstruction::SetSwitchboardPrice { price, expo }
-        .try_to_vec()
-        .unwrap();
-    Instruction {
-        program_id,
-        accounts: vec![AccountMeta::new(switchboard_feed, false)],
-        data,
-    }
-}
-
-pub fn init_switchboard(program_id: Pubkey, switchboard_feed: Pubkey) -> Instruction {
-    let data = MockPythInstruction::InitSwitchboard.try_to_vec().unwrap();
-    Instruction {
-        program_id,
-        accounts: vec![AccountMeta::new(switchboard_feed, false)],
         data,
     }
 }

--- a/token-lending/program/tests/helpers/mock_switchboard.rs
+++ b/token-lending/program/tests/helpers/mock_switchboard.rs
@@ -114,7 +114,9 @@ pub fn set_switchboard_price(
 }
 
 pub fn init_switchboard(program_id: Pubkey, switchboard_feed: Pubkey) -> Instruction {
-    let data = MockSwitchboardInstruction::InitSwitchboard.try_to_vec().unwrap();
+    let data = MockSwitchboardInstruction::InitSwitchboard
+        .try_to_vec()
+        .unwrap();
     Instruction {
         program_id,
         accounts: vec![AccountMeta::new(switchboard_feed, false)],

--- a/token-lending/program/tests/helpers/mock_switchboard.rs
+++ b/token-lending/program/tests/helpers/mock_switchboard.rs
@@ -1,0 +1,123 @@
+/// mock oracle prices in tests with this program.
+use solana_program::{
+    account_info::AccountInfo,
+    clock::Clock,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    msg,
+    pubkey::Pubkey,
+    sysvar::Sysvar,
+};
+use std::cell::RefMut;
+use switchboard_v2::{AggregatorAccountData, SwitchboardDecimal};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use spl_token::solana_program::{account_info::next_account_info, program_error::ProgramError};
+use thiserror::Error;
+
+#[derive(BorshSerialize, BorshDeserialize)]
+pub enum MockSwitchboardInstruction {
+    /// Accounts:
+    /// 0: AggregatorAccount
+    InitSwitchboard,
+
+    /// Accounts:
+    /// 0: AggregatorAccount
+    SetSwitchboardPrice { price: i64, expo: i32 },
+}
+
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    Processor::process(program_id, accounts, instruction_data)
+}
+
+pub struct Processor;
+impl Processor {
+    pub fn process(
+        _program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        instruction_data: &[u8],
+    ) -> ProgramResult {
+        let instruction = MockSwitchboardInstruction::try_from_slice(instruction_data)?;
+        let account_info_iter = &mut accounts.iter().peekable();
+
+        match instruction {
+            MockSwitchboardInstruction::InitSwitchboard => {
+                msg!("Mock Switchboard: Init Switchboard");
+                let switchboard_feed = next_account_info(account_info_iter)?;
+                let mut data = switchboard_feed.try_borrow_mut_data()?;
+
+                let discriminator = [217, 230, 65, 101, 201, 162, 27, 125];
+                data[0..8].copy_from_slice(&discriminator);
+                Ok(())
+            }
+            MockSwitchboardInstruction::SetSwitchboardPrice { price, expo } => {
+                msg!("Mock Switchboard: Set Switchboard price");
+                let switchboard_feed = next_account_info(account_info_iter)?;
+                let data = switchboard_feed.try_borrow_mut_data()?;
+
+                let mut aggregator_account: RefMut<AggregatorAccountData> =
+                    RefMut::map(data, |data| {
+                        bytemuck::from_bytes_mut(
+                            &mut data[8..std::mem::size_of::<AggregatorAccountData>() + 8],
+                        )
+                    });
+
+                aggregator_account.min_oracle_results = 1;
+                aggregator_account.latest_confirmed_round.num_success = 1;
+                aggregator_account.latest_confirmed_round.result = SwitchboardDecimal {
+                    mantissa: price as i128,
+                    scale: expo as u32,
+                };
+                aggregator_account.latest_confirmed_round.round_open_slot = Clock::get()?.slot;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Error, Debug, Copy, Clone)]
+pub enum MockSwitchboardError {
+    /// Invalid instruction
+    #[error("Invalid Instruction")]
+    InvalidInstruction,
+    #[error("The account is not currently owned by the program")]
+    IncorrectProgramId,
+    #[error("Failed to deserialize")]
+    FailedToDeserialize,
+}
+
+impl From<MockSwitchboardError> for ProgramError {
+    fn from(e: MockSwitchboardError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+
+pub fn set_switchboard_price(
+    program_id: Pubkey,
+    switchboard_feed: Pubkey,
+    price: i64,
+    expo: i32,
+) -> Instruction {
+    let data = MockSwitchboardInstruction::SetSwitchboardPrice { price, expo }
+        .try_to_vec()
+        .unwrap();
+    Instruction {
+        program_id,
+        accounts: vec![AccountMeta::new(switchboard_feed, false)],
+        data,
+    }
+}
+
+pub fn init_switchboard(program_id: Pubkey, switchboard_feed: Pubkey) -> Instruction {
+    let data = MockSwitchboardInstruction::InitSwitchboard.try_to_vec().unwrap();
+    Instruction {
+        program_id,
+        accounts: vec![AccountMeta::new(switchboard_feed, false)],
+        data,
+    }
+}

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -53,7 +53,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         added_borrow_weight_bps: 0,
         reserve_type: ReserveType::Regular,
         scaled_price_offset_bps: 0,
-        extra_oracle_pubkey: None
+        extra_oracle_pubkey: None,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -53,6 +53,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         added_borrow_weight_bps: 0,
         reserve_type: ReserveType::Regular,
         scaled_price_offset_bps: 0,
+        extra_oracle_pubkey: None
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -4,6 +4,7 @@ pub mod flash_loan_proxy;
 pub mod flash_loan_receiver;
 pub mod genesis;
 pub mod mock_pyth;
+pub mod mock_switchboard;
 pub mod solend_program_test;
 
 use bytemuck::{cast_slice_mut, from_bytes_mut, try_cast_slice_mut, Pod, PodCastError};
@@ -68,6 +69,11 @@ pub mod usdt_mint {
 pub mod wsol_mint {
     // fake mint, not the real wsol bc i can't mint wsol programmatically
     solana_program::declare_id!("So1m5eppzgokXLBt9Cg8KCMPWhHfTzVaGh26Y415MRG");
+}
+
+pub mod msol_mint {
+    // fake mint, not the real wsol bc i can't mint wsol programmatically
+    solana_program::declare_id!("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So");
 }
 
 pub mod bonk_mint {

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -414,9 +414,7 @@ impl SolendProgramTest {
     }
 
     pub async fn init_pyth_feed(&mut self, mint: &Pubkey) -> Pubkey {
-        let pyth_price_pubkey = self
-            .create_account(3312, &pyth_mainnet::id(), None)
-            .await;
+        let pyth_price_pubkey = self.create_account(3312, &pyth_mainnet::id(), None).await;
         let pyth_product_pubkey = self
             .create_account(PROD_ACCT_SIZE, &pyth_mainnet::id(), None)
             .await;
@@ -807,7 +805,7 @@ impl Info<LendingMarket> {
                 reserve.pubkey,
                 reserve.account.liquidity.pyth_oracle_pubkey,
                 reserve.account.liquidity.switchboard_oracle_pubkey,
-                reserve.account.config.extra_oracle_pubkey
+                reserve.account.config.extra_oracle_pubkey,
             ),
             redeem_reserve_collateral(
                 solend_program::id(),
@@ -903,7 +901,7 @@ impl Info<LendingMarket> {
                     reserve.pubkey,
                     reserve.account.liquidity.pyth_oracle_pubkey,
                     reserve.account.liquidity.switchboard_oracle_pubkey,
-                    reserve.account.config.extra_oracle_pubkey
+                    reserve.account.config.extra_oracle_pubkey,
                 ),
             ],
             None,
@@ -949,7 +947,7 @@ impl Info<LendingMarket> {
                     reserve.pubkey,
                     reserve.account.liquidity.pyth_oracle_pubkey,
                     reserve.account.liquidity.switchboard_oracle_pubkey,
-                    reserve.account.config.extra_oracle_pubkey
+                    reserve.account.config.extra_oracle_pubkey,
                 )
             })
             .collect();
@@ -1076,7 +1074,7 @@ impl Info<LendingMarket> {
                 reserve.pubkey,
                 reserve.account.liquidity.pyth_oracle_pubkey,
                 reserve.account.liquidity.switchboard_oracle_pubkey,
-                reserve.account.config.extra_oracle_pubkey
+                reserve.account.config.extra_oracle_pubkey,
             ),
             redeem_fees(
                 solend_program::id(),

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use helpers::solend_program_test::{SolendProgramTest, User};
 use helpers::*;
-use mock_pyth::mock_pyth_program;
 use solana_program::instruction::InstructionError;
 use solana_program_test::*;
 use solana_sdk::signature::Keypair;
@@ -13,6 +12,7 @@ use solana_sdk::transaction::TransactionError;
 use solend_program::error::LendingError;
 use solend_program::instruction::init_lending_market;
 use solend_program::state::{LendingMarket, RateLimiter, PROGRAM_VERSION};
+use solend_sdk::{pyth_mainnet, switchboard_v2_mainnet};
 
 #[tokio::test]
 async fn test_success() {
@@ -33,8 +33,8 @@ async fn test_success() {
             owner: lending_market_owner.keypair.pubkey(),
             quote_currency: QUOTE_CURRENCY,
             token_program_id: spl_token::id(),
-            oracle_program_id: mock_pyth_program::id(),
-            switchboard_oracle_program_id: mock_pyth_program::id(),
+            oracle_program_id: pyth_mainnet::id(),
+            switchboard_oracle_program_id: switchboard_v2_mainnet::id(),
             rate_limiter: RateLimiter::default(),
             whitelisted_liquidator: None,
             risk_authority: lending_market_owner.keypair.pubkey(),
@@ -63,8 +63,8 @@ async fn test_already_initialized() {
                 lending_market_owner.keypair.pubkey(),
                 QUOTE_CURRENCY,
                 keypair.pubkey(),
-                mock_pyth_program::id(),
-                mock_pyth_program::id(),
+                pyth_mainnet::id(),
+                switchboard_v2_mainnet::id(),
             )],
             None,
         )

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::solend_program_test::PriceArgs;
-use crate::solend_program_test::custom_scenario;
+
 use crate::solend_program_test::BalanceChecker;
 use crate::solend_program_test::MintAccount;
 use crate::solend_program_test::MintSupplyChange;

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
+use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::BalanceChecker;
 use crate::solend_program_test::MintAccount;
 use crate::solend_program_test::MintSupplyChange;

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -170,6 +170,7 @@ async fn test_success() {
                 accumulated_protocol_fees_wads: Decimal::zero(),
                 market_price: Decimal::from(10u64),
                 smoothed_market_price: Decimal::from(10u64),
+                extra_market_price: None
             },
             collateral: ReserveCollateral {
                 mint_pubkey: reserve_collateral_mint_pubkey,

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -445,7 +445,7 @@ async fn test_use_price_weight() {
 
 #[tokio::test]
 async fn test_use_extra_oracle() {
-    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+    let (mut test, lending_market, reserves, _obligations, _users, lending_market_owner) =
         custom_scenario(
             &[ReserveArgs {
                 mint: msol_mint::id(),
@@ -610,7 +610,7 @@ async fn test_use_extra_oracle() {
 
 #[tokio::test]
 async fn test_use_extra_oracle_bad_cases() {
-    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+    let (mut test, lending_market, reserves, _obligations, _users, lending_market_owner) =
         custom_scenario(
             &[ReserveArgs {
                 mint: msol_mint::id(),

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -442,3 +442,171 @@ async fn test_use_price_weight() {
         Decimal::from(16u64)
     );
 }
+
+#[tokio::test]
+async fn test_use_extra_oracle() {
+    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+        custom_scenario(
+            &[ReserveArgs {
+                mint: msol_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 1000,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            }],
+            &[],
+        )
+        .await;
+
+    let msol_reserve = &reserves[0];
+
+    // add extra pyth oracle
+    let wsol_pyth_feed = test.init_pyth_feed(&wsol_mint::id()).await;
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 5,
+            conf: 0,
+            expo: 0,
+            ema_price: 5,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_pyth_feed),
+                scaled_price_offset_bps: 2_000,
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account,
+        Reserve {
+            last_update: LastUpdate {
+                slot: 1001,
+                stale: false
+            },
+            liquidity: ReserveLiquidity {
+                market_price: Decimal::from(12u64),
+                smoothed_market_price: Decimal::from(12u64),
+                extra_market_price: Some(Decimal::from(6u64)),
+                ..msol_reserve.account.liquidity
+            },
+            ..msol_reserve.account
+        }
+    );
+
+    // add extra switchboard oracle
+    let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    let wsol_switchboard_feed = test.init_switchboard_feed(&wsol_mint::id()).await;
+    test.set_switchboard_price(
+        &wsol_mint::id(),
+        SwitchboardPriceArgs { price: 2, expo: 0 }
+    )
+    .await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_switchboard_feed),
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account,
+        Reserve {
+            last_update: LastUpdate {
+                slot: 1002,
+                stale: false
+            },
+            liquidity: ReserveLiquidity {
+                extra_market_price: Some(Decimal::from_percent(240)),
+                ..msol_reserve.account.liquidity
+            },
+            ..msol_reserve.account
+        }
+    );
+
+    test.advance_clock_by_slots(1).await;
+
+    // remove extra oracle, make sure extra price is None now
+    let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: None,
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+    let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+
+    lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account,
+        Reserve {
+            last_update: LastUpdate {
+                slot: 1003,
+                stale: false
+            },
+            liquidity: ReserveLiquidity {
+                extra_market_price: None,
+                ..msol_reserve.account.liquidity
+            },
+            ..msol_reserve.account
+        }
+    );
+}

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -514,7 +514,7 @@ async fn test_use_extra_oracle() {
             liquidity: ReserveLiquidity {
                 market_price: Decimal::from(12u64),
                 smoothed_market_price: Decimal::from(12u64),
-                extra_market_price: Some(Decimal::from(6u64)),
+                extra_market_price: Some(Decimal::from(5u64)),
                 ..msol_reserve.account.liquidity
             },
             ..msol_reserve.account
@@ -559,7 +559,7 @@ async fn test_use_extra_oracle() {
                 stale: false
             },
             liquidity: ReserveLiquidity {
-                extra_market_price: Some(Decimal::from_percent(240)),
+                extra_market_price: Some(Decimal::from(2u64)),
                 ..msol_reserve.account.liquidity
             },
             ..msol_reserve.account

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -524,11 +524,8 @@ async fn test_use_extra_oracle() {
     // add extra switchboard oracle
     let msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
     let wsol_switchboard_feed = test.init_switchboard_feed(&wsol_mint::id()).await;
-    test.set_switchboard_price(
-        &wsol_mint::id(),
-        SwitchboardPriceArgs { price: 2, expo: 0 }
-    )
-    .await;
+    test.set_switchboard_price(&wsol_mint::id(), SwitchboardPriceArgs { price: 2, expo: 0 })
+        .await;
 
     lending_market
         .update_reserve_config(
@@ -608,5 +605,119 @@ async fn test_use_extra_oracle() {
             },
             ..msol_reserve.account
         }
+    );
+}
+
+#[tokio::test]
+async fn test_use_extra_oracle_bad_cases() {
+    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+        custom_scenario(
+            &[ReserveArgs {
+                mint: msol_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 1000,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            }],
+            &[],
+        )
+        .await;
+
+    let msol_reserve = &reserves[0];
+
+    // add extra pyth oracle
+    let wsol_pyth_feed = test.init_pyth_feed(&wsol_mint::id()).await;
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 5,
+            conf: 0,
+            expo: 0,
+            ema_price: 5,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_pyth_feed),
+                scaled_price_offset_bps: 2_000,
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1000).await;
+
+    test.set_price(
+        &msol_mint::id(),
+        &PriceArgs {
+            price: 10,
+            conf: 0,
+            expo: 0,
+            ema_price: 10,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    let mut msol_reserve = test.load_account::<Reserve>(reserves[0].pubkey).await;
+
+    // this should fail because the extra oracle is stale
+    let err = lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(LendingError::InvalidOracleConfig as u32)
+        )
+    );
+
+    msol_reserve.account.config.extra_oracle_pubkey =
+        Some(msol_reserve.account.liquidity.pyth_oracle_pubkey);
+    // this should fail because the extra oracle passed in doesn't match
+    let err = lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
+    );
+
+    msol_reserve.account.config.extra_oracle_pubkey = None;
+    // this should fail because there's no extra oracle passed in
+    let err = lending_market
+        .refresh_reserve(&mut test, &msol_reserve)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
     );
 }

--- a/token-lending/program/tests/update_reserve_config.rs
+++ b/token-lending/program/tests/update_reserve_config.rs
@@ -1,6 +1,10 @@
 #![cfg(feature = "test-bpf")]
 
+use crate::solend_program_test::SwitchboardPriceArgs;
+use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::Oracle;
+use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
 use solana_sdk::instruction::AccountMeta;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::PUBKEY_BYTES;
@@ -409,4 +413,113 @@ pub fn malicious_update_reserve_config(
         }
         .pack(),
     }
+}
+
+#[tokio::test]
+async fn test_add_extra_oracle() {
+    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+        custom_scenario(
+            &[ReserveArgs {
+                mint: msol_mint::id(),
+                config: test_reserve_config(),
+                liquidity_amount: 1000,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            }],
+            &[],
+        )
+        .await;
+
+    let msol_reserve = &reserves[0];
+
+    let wsol_pyth_feed = test.init_pyth_feed(&wsol_mint::id()).await;
+    test.set_price(
+        &wsol_mint::id(),
+        &PriceArgs {
+            price: 5,
+            conf: 0,
+            expo: 0,
+            ema_price: 5,
+            ema_conf: 0,
+        },
+    )
+    .await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_pyth_feed),
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account.config.extra_oracle_pubkey,
+        Some(wsol_pyth_feed)
+    );
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: None,
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account.config.extra_oracle_pubkey,
+        None
+    );
+
+    let wsol_switchboard_feed = test.init_switchboard_feed(&wsol_mint::id()).await;
+    test.set_switchboard_price(
+        &wsol_mint::id(),
+        SwitchboardPriceArgs {
+            price: 5,
+            expo: 0,
+        },
+    )
+    .await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            msol_reserve,
+            ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_switchboard_feed),
+                ..msol_reserve.account.config
+            },
+            msol_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
+    assert_eq!(
+        msol_reserve_post.account.config.extra_oracle_pubkey,
+        Some(wsol_switchboard_feed)
+    );
 }

--- a/token-lending/program/tests/update_reserve_config.rs
+++ b/token-lending/program/tests/update_reserve_config.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "test-bpf")]
 
-use crate::solend_program_test::SwitchboardPriceArgs;
 use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::Oracle;
 use crate::solend_program_test::PriceArgs;
 use crate::solend_program_test::ReserveArgs;
+use crate::solend_program_test::SwitchboardPriceArgs;
 use solana_sdk::instruction::AccountMeta;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::PUBKEY_BYTES;
@@ -467,8 +467,14 @@ async fn test_add_extra_oracle() {
 
     let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
     assert_eq!(
-        msol_reserve_post.account.config.extra_oracle_pubkey,
-        Some(wsol_pyth_feed)
+        msol_reserve_post.account,
+        Reserve {
+            config: ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_pyth_feed),
+                ..msol_reserve.account.config
+            },
+            ..msol_reserve.account.clone()
+        }
     );
 
     lending_market
@@ -488,19 +494,19 @@ async fn test_add_extra_oracle() {
 
     let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
     assert_eq!(
-        msol_reserve_post.account.config.extra_oracle_pubkey,
-        None
+        msol_reserve_post.account,
+        Reserve {
+            config: ReserveConfig {
+                extra_oracle_pubkey: None,
+                ..msol_reserve.account.config
+            },
+            ..msol_reserve.account.clone()
+        }
     );
 
     let wsol_switchboard_feed = test.init_switchboard_feed(&wsol_mint::id()).await;
-    test.set_switchboard_price(
-        &wsol_mint::id(),
-        SwitchboardPriceArgs {
-            price: 5,
-            expo: 0,
-        },
-    )
-    .await;
+    test.set_switchboard_price(&wsol_mint::id(), SwitchboardPriceArgs { price: 5, expo: 0 })
+        .await;
 
     lending_market
         .update_reserve_config(
@@ -519,7 +525,13 @@ async fn test_add_extra_oracle() {
 
     let msol_reserve_post = test.load_account::<Reserve>(msol_reserve.pubkey).await;
     assert_eq!(
-        msol_reserve_post.account.config.extra_oracle_pubkey,
-        Some(wsol_switchboard_feed)
+        msol_reserve_post.account,
+        Reserve {
+            config: ReserveConfig {
+                extra_oracle_pubkey: Some(wsol_switchboard_feed),
+                ..msol_reserve.account.config
+            },
+            ..msol_reserve.account.clone()
+        }
     );
 }

--- a/token-lending/program/tests/update_reserve_config.rs
+++ b/token-lending/program/tests/update_reserve_config.rs
@@ -417,7 +417,7 @@ pub fn malicious_update_reserve_config(
 
 #[tokio::test]
 async fn test_add_extra_oracle() {
-    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+    let (mut test, lending_market, reserves, _obligations, _users, lending_market_owner) =
         custom_scenario(
             &[ReserveArgs {
                 mint: msol_mint::id(),

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1101,7 +1101,7 @@ pub fn init_reserve(
         &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
         &program_id,
     );
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(source_liquidity_pubkey, false),
         AccountMeta::new(destination_collateral_pubkey, false),
         AccountMeta::new(reserve_pubkey, false),
@@ -1120,6 +1120,11 @@ pub fn init_reserve(
         AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];
+
+    if let Some(extra_oracle_pubkey) = config.extra_oracle_pubkey {
+        accounts.push(AccountMeta::new_readonly(extra_oracle_pubkey, false));
+    }
+
     Instruction {
         program_id,
         accounts,
@@ -1137,12 +1142,18 @@ pub fn refresh_reserve(
     reserve_pubkey: Pubkey,
     reserve_liquidity_pyth_oracle_pubkey: Pubkey,
     reserve_liquidity_switchboard_oracle_pubkey: Pubkey,
+    extra_oracle_pubkey: Option<Pubkey>,
 ) -> Instruction {
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(reserve_pubkey, false),
         AccountMeta::new_readonly(reserve_liquidity_pyth_oracle_pubkey, false),
         AccountMeta::new_readonly(reserve_liquidity_switchboard_oracle_pubkey, false),
     ];
+
+    if let Some(extra_oracle_pubkey) = extra_oracle_pubkey {
+        accounts.push(AccountMeta::new_readonly(extra_oracle_pubkey, false));
+    }
+
     Instruction {
         program_id,
         accounts,
@@ -1531,7 +1542,7 @@ pub fn update_reserve_config(
         &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
         &program_id,
     );
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(reserve_pubkey, false),
         AccountMeta::new_readonly(lending_market_pubkey, false),
         AccountMeta::new_readonly(lending_market_authority_pubkey, false),
@@ -1540,6 +1551,11 @@ pub fn update_reserve_config(
         AccountMeta::new_readonly(pyth_price_pubkey, false),
         AccountMeta::new_readonly(switchboard_feed_pubkey, false),
     ];
+
+    if let Some(extra_oracle_pubkey) = config.extra_oracle_pubkey {
+        accounts.push(AccountMeta::new_readonly(extra_oracle_pubkey, false));
+    }
+
     Instruction {
         program_id,
         accounts,

--- a/token-lending/sdk/src/lib.rs
+++ b/token-lending/sdk/src/lib.rs
@@ -37,3 +37,8 @@ pub mod switchboard_v2_mainnet {
 pub mod switchboard_v2_devnet {
     solana_program::declare_id!("2TfB33aLaneQb5TNVwyDz3jSZXS6jdW2ARw1Dgf84XCG");
 }
+
+/// Mainnet program id for pyth
+pub mod pyth_mainnet {
+    solana_program::declare_id!("FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH");
+}

--- a/token-lending/sdk/src/oracles.rs
+++ b/token-lending/sdk/src/oracles.rs
@@ -26,7 +26,11 @@ pub fn get_oracle_type(extra_oracle_info: &AccountInfo) -> Result<OracleType, Pr
         return Ok(OracleType::Switchboard);
     }
 
-    msg!("Could not find oracle type for {:?} with owner {:?}", extra_oracle_info.key, extra_oracle_info.owner);
+    msg!(
+        "Could not find oracle type for {:?} with owner {:?}",
+        extra_oracle_info.key,
+        extra_oracle_info.owner
+    );
     Err(LendingError::InvalidOracleConfig.into())
 }
 

--- a/token-lending/sdk/src/oracles.rs
+++ b/token-lending/sdk/src/oracles.rs
@@ -3,7 +3,9 @@ use crate::{
     self as solend_program,
     error::LendingError,
     math::{Decimal, TryDiv, TryMul},
+    pyth_mainnet,
     state::LendingMarket,
+    switchboard_v2_mainnet,
 };
 use pyth_sdk_solana::Price;
 // use pyth_sdk_solana;
@@ -11,6 +13,22 @@ use solana_program::{
     account_info::AccountInfo, msg, program_error::ProgramError, sysvar::clock::Clock,
 };
 use std::{convert::TryInto, result::Result};
+
+pub enum OracleType {
+    Pyth,
+    Switchboard,
+}
+
+pub fn get_oracle_type(extra_oracle_info: &AccountInfo) -> Result<OracleType, ProgramError> {
+    if *extra_oracle_info.owner == pyth_mainnet::id() {
+        return Ok(OracleType::Pyth);
+    } else if *extra_oracle_info.owner == switchboard_v2_mainnet::id() {
+        return Ok(OracleType::Switchboard);
+    }
+
+    msg!("Could not find oracle type for {:?} with owner {:?}", extra_oracle_info.key, extra_oracle_info.owner);
+    Err(LendingError::InvalidOracleConfig.into())
+}
 
 pub fn validate_pyth_price_account_info(
     lending_market: &LendingMarket,

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -947,6 +947,54 @@ mod test {
                 // 10 cSOL * 2(SOL/cSOL) * 0.5(ltv) * $5 = $50, which is exactly what we want.
                 expected_max_withdraw_amount: 10 * LAMPORTS_PER_SOL, // 10 cSOL
             }),
+            // regular case
+            Just(MaxWithdrawAmountTestCase {
+                obligation: Obligation {
+                    deposits: vec![ObligationCollateral {
+                        deposited_amount: 20 * LAMPORTS_PER_SOL,
+                        ..ObligationCollateral::default()
+                    }],
+                    borrows: vec![ObligationLiquidity {
+                        borrowed_amount_wads: Decimal::from(10u64),
+                        ..ObligationLiquidity::default()
+                    }],
+
+                    allowed_borrow_value: Decimal::from(100u64),
+                    borrowed_value_upper_bound: Decimal::from(50u64),
+                    ..Obligation::default()
+                },
+
+                reserve: Reserve {
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 50,
+                        ..ReserveConfig::default()
+                    },
+                    liquidity: ReserveLiquidity {
+                        available_amount: 100 * LAMPORTS_PER_SOL,
+                        borrowed_amount_wads: Decimal::zero(),
+                        market_price: Decimal::from(10u64),
+                        smoothed_market_price: Decimal::from(10u64),
+                        extra_market_price: Some(Decimal::from(5u64)),
+                        mint_decimals: 9,
+                        ..ReserveLiquidity::default()
+                    },
+                    collateral: ReserveCollateral {
+                        mint_total_supply: 50 * LAMPORTS_PER_SOL,
+                        ..ReserveCollateral::default()
+                    },
+                    ..Reserve::default()
+                },
+
+                // deposited 20 cSOL
+                // => allowed borrow value: 20 cSOL * 2(SOL/cSOL) * 0.5(ltv) * $5 = $100
+                // => borrowed value upper bound: $50
+                // => max withdraw value: ($100 - $50) / 0.5 = $100
+                // => max withdraw liquidity amount: $100 / $5 = 20 SOL
+                // => max withdraw collateral amount: 20 SOL / 2(SOL/cSOL) = 10 cSOL
+                // after withdrawing, the new allowed borrow value is:
+                // 10 cSOL * 2(SOL/cSOL) * 0.5(ltv) * $5 = $50, which is exactly what we want.
+                expected_max_withdraw_amount: 10 * LAMPORTS_PER_SOL, // 10 cSOL
+            }),
             // same case as above but this time we didn't deposit that much collateral
             Just(MaxWithdrawAmountTestCase {
                 obligation: Obligation {

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -133,7 +133,7 @@ impl Obligation {
 
         // convert max_withdraw_value to max withdraw liquidity amount
 
-        // why is min used and not max? seems scary
+        // why is lower bound used and not upper bound? seems scary
         //
         // the tldr is that allowed borrow value is calculated with the minimum
         // of the spot price and the smoothed price, so we have to use the min here to be
@@ -146,10 +146,7 @@ impl Obligation {
         // as using min.
         //
         // therefore, we use min for the better UX.
-        let price = min(
-            withdraw_reserve.liquidity.market_price,
-            withdraw_reserve.liquidity.smoothed_market_price,
-        );
+        let price = withdraw_reserve.price_lower_bound();
 
         let decimals = 10u64
             .checked_pow(withdraw_reserve.liquidity.mint_decimals as u32)

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -2076,7 +2076,7 @@ mod test {
 
     #[test]
     fn price() {
-        let reserve = Reserve {
+        let mut reserve = Reserve {
             liquidity: ReserveLiquidity {
                 mint_decimals: 9,
                 market_price: Decimal::from(25u64),
@@ -2088,6 +2088,12 @@ mod test {
 
         assert_eq!(reserve.price_upper_bound(), Decimal::from(50u64));
         assert_eq!(reserve.price_lower_bound(), Decimal::from(25u64));
+
+        reserve.liquidity.extra_market_price = Some(Decimal::from(75u64));
+        assert_eq!(reserve.price_upper_bound(), Decimal::from(75u64));
+
+        reserve.liquidity.extra_market_price = Some(Decimal::from(10u64));
+        assert_eq!(reserve.price_lower_bound(), Decimal::from(10u64));
     }
 
     #[test]

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -107,18 +107,30 @@ impl Reserve {
 
     /// Upper bound price for reserve mint
     pub fn price_upper_bound(&self) -> Decimal {
-        std::cmp::max(
+        let price = std::cmp::max(
             self.liquidity.market_price,
             self.liquidity.smoothed_market_price,
-        )
+        );
+
+        if let Some(extra_price) = self.liquidity.extra_market_price {
+            std::cmp::max(price, extra_price)
+        } else {
+            price
+        }
     }
 
     /// Lower bound price for reserve mint
     pub fn price_lower_bound(&self) -> Decimal {
-        std::cmp::min(
+        let price = std::cmp::min(
             self.liquidity.market_price,
             self.liquidity.smoothed_market_price,
-        )
+        );
+
+        if let Some(extra_price) = self.liquidity.extra_market_price {
+            std::cmp::min(price, extra_price)
+        } else {
+            price
+        }
     }
 
     /// Convert USD to liquidity tokens.

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -2760,7 +2760,6 @@ mod test {
 
                 result: Err(LendingError::BorrowTooLarge.into()),
             }),
-
             // borrow enough where it would be fine if we were just using the market + ema price but
             // not fine when using market + ema + extra price
             Just(CalculateBorrowTestCase {

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -936,7 +936,7 @@ pub struct ReserveConfig {
     /// Type of the reserve (Regular, Isolated)
     pub reserve_type: ReserveType,
     /// scaled price offset in basis points. Exclusively used to calculate a more reliable asset price for
-    /// staked assets (mSOL, stETH).
+    /// staked assets (mSOL, stETH). Not used on extra oracle
     pub scaled_price_offset_bps: i64,
     /// Extra oracle. Only used to limit borrows and withdrawals.
     pub extra_oracle_pubkey: Option<Pubkey>,


### PR DESCRIPTION
Used to make borrows and withdraws even more conservative. Does not affect liquidation price. 

because this oracle is only used to limit borrows and withdraws,  we don't wanna fail the tx if this oracle is stale or has a high confidence interval