### PR TITLE
Collateralization Limits Final

### DIFF
--- a/token-lending/cli/src/lending_state.rs
+++ b/token-lending/cli/src/lending_state.rs
@@ -129,6 +129,11 @@ impl SolendState {
             self.obligation_pubkey,
             withdraw_reserve.lending_market,
             self.obligation.owner,
+            self.obligation
+                .deposits
+                .iter()
+                .map(|d| d.deposit_reserve)
+                .collect(),
         ));
 
         instructions

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1143,6 +1143,7 @@ fn main() {
             let reserve_type = value_of(arg_matches, "reserve_type").unwrap();
             let scaled_price_offset_bps = value_of(arg_matches, "scaled_price_offset_bps").unwrap();
             let extra_oracle_pubkey = pubkey_of(arg_matches, "extra_oracle_pubkey").unwrap();
+            let attributed_borrow_limit = value_of(arg_matches, "attributed_borrow_limit").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -1198,6 +1199,7 @@ fn main() {
                     reserve_type,
                     scaled_price_offset_bps,
                     extra_oracle_pubkey: Some(extra_oracle_pubkey),
+                    attributed_borrow_limit,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1143,7 +1143,10 @@ fn main() {
             let reserve_type = value_of(arg_matches, "reserve_type").unwrap();
             let scaled_price_offset_bps = value_of(arg_matches, "scaled_price_offset_bps").unwrap();
             let extra_oracle_pubkey = pubkey_of(arg_matches, "extra_oracle_pubkey").unwrap();
-            let attributed_borrow_limit = value_of(arg_matches, "attributed_borrow_limit").unwrap();
+            let attributed_borrow_limit_open =
+                value_of(arg_matches, "attributed_borrow_limit_open").unwrap();
+            let attributed_borrow_limit_close =
+                value_of(arg_matches, "attributed_borrow_limit_close").unwrap();
 
             let borrow_fee_wad = (borrow_fee * WAD as f64) as u64;
             let flash_loan_fee_wad = (flash_loan_fee * WAD as f64) as u64;
@@ -1199,7 +1202,8 @@ fn main() {
                     reserve_type,
                     scaled_price_offset_bps,
                     extra_oracle_pubkey: Some(extra_oracle_pubkey),
-                    attributed_borrow_limit,
+                    attributed_borrow_limit_open,
+                    attributed_borrow_limit_close,
                 },
                 source_liquidity_pubkey,
                 source_liquidity_owner_keypair,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1007,17 +1007,6 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
     let mut true_borrow_value = Decimal::zero();
 
-    let mut arr = [0u8; 206];
-    for i in 0..arr.len() {
-        arr[i] = (i % 256) as u8;
-    }
-    let mut s = 0;
-    for i in 0..arr.len() {
-        s += arr[i];
-    }
-    msg!("s: {}", s);
-
-
     for (index, collateral) in obligation.deposits.iter_mut().enumerate() {
         let deposit_reserve_info = next_account_info(account_info_iter)?;
         if deposit_reserve_info.owner != program_id {
@@ -1172,13 +1161,21 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         // maybe need to do a saturating sub here in case there are precision issues
         deposit_reserve.attributed_borrow_value = deposit_reserve
             .attributed_borrow_value
-            .try_sub(collateral.attributed_borrow_value)?;
+            .try_sub(collateral.attributed_borrow_value)
+            .map_err(|e| {
+                msg!("sub failed");
+                e
+            })?;
 
         if obligation.deposited_value > Decimal::zero() {
             collateral.attributed_borrow_value = collateral
                 .market_value
                 .try_mul(obligation.borrowed_value)?
-                .try_div(obligation.deposited_value)?;
+                .try_div(obligation.deposited_value)
+                .map_err(|e| {
+                    msg!("div failed");
+                    e
+                })?;
         } else {
             collateral.attributed_borrow_value = Decimal::zero();
         }

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -2075,7 +2075,7 @@ fn _liquidate_obligation<'a>(
         return Err(LendingError::ReserveStale.into());
     }
 
-    let withdraw_reserve = Box::new(Reserve::unpack(&withdraw_reserve_info.data.borrow())?);
+    let mut withdraw_reserve = Box::new(Reserve::unpack(&withdraw_reserve_info.data.borrow())?);
     if withdraw_reserve_info.owner != program_id {
         msg!("Withdraw reserve provided is not owned by the lending program");
         return Err(LendingError::InvalidAccountOwner.into());
@@ -2189,6 +2189,21 @@ fn _liquidate_obligation<'a>(
     repay_reserve.liquidity.repay(repay_amount, settle_amount)?;
     repay_reserve.last_update.mark_stale();
     Reserve::pack(*repay_reserve, &mut repay_reserve_info.data.borrow_mut())?;
+
+    // if there is a full withdraw here (which can happen on a full liquidation), then the borrow
+    // attribution value needs to be updated on the reserve. note that we can't depend on
+    // refresh_obligation to update this correctly because the ObligationCollateral object will be
+    // deleted after this call.
+    if withdraw_amount == collateral.deposited_amount {
+        withdraw_reserve.attributed_borrow_value = withdraw_reserve
+            .attributed_borrow_value
+            .saturating_sub(collateral.market_value);
+
+        Reserve::pack(
+            *withdraw_reserve,
+            &mut withdraw_reserve_info.data.borrow_mut(),
+        )?;
+    }
 
     obligation.repay(settle_amount, liquidity_index)?;
     obligation.withdraw(withdraw_amount, collateral_index)?;

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -32,7 +32,7 @@ use solana_program::{
         Sysvar,
     },
 };
-use solend_sdk::state::ObligationCollateral;
+
 use solend_sdk::{
     oracles::{
         get_oracle_type, get_pyth_price_unchecked, validate_pyth_price_account_info, OracleType,
@@ -1217,7 +1217,7 @@ fn update_borrow_attribution_values(
                 deposit_reserve_info.key,
                 deposit_reserve.liquidity.mint_pubkey
             );
-            return Err(LendingError::InvalidAmount.into());
+            return Err(LendingError::BorrowAttributionLimitExceeded.into());
         }
 
         Reserve::pack(deposit_reserve, &mut deposit_reserve_info.data.borrow_mut())?;
@@ -1821,55 +1821,15 @@ fn process_borrow_obligation_liquidity(
             })?;
     }
 
-    // check that the borrow doesn't exceed the borrow attribution limit for any of the deposit
-    // reserves
-    let borrow_value_usd = borrow_reserve.market_value(borrow_amount)?;
-    for deposit in obligation.deposits.iter_mut() {
-        let deposit_reserve_info = next_account_info(account_info_iter)?;
-        if *deposit_reserve_info.key != deposit.deposit_reserve {
-            msg!("Deposit reserve provided does not match the deposit reserve in the obligation");
-            return Err(LendingError::InvalidAccountInput.into());
-        }
-
-        let mut reserve = Reserve::unpack(&deposit_reserve_info.data.borrow())?;
-
-        // edge case. if the deposit reserve == borrow reserve, we need to use the already loaded
-        // borrow reserve instead of unpacking it again, otherwise we'll lose prior changes
-        let deposit_reserve = if deposit_reserve_info.key != borrow_reserve_info.key {
-            &mut reserve
-        } else {
-            &mut borrow_reserve
-        };
-
-        // divbyzero not possible since we check that it's nonzero earlier
-        let additional_borrow_attributed = borrow_value_usd
-            .try_mul(deposit.market_value)?
-            .try_div(obligation.deposited_value)?;
-
-        deposit_reserve.attributed_borrow_value = deposit_reserve
-            .attributed_borrow_value
-            .try_add(additional_borrow_attributed)?;
-
-        if deposit_reserve.attributed_borrow_value
-            > Decimal::from(deposit_reserve.config.attributed_borrow_limit)
-        {
-            msg!("Borrow would exceed the deposit reserve's borrow attribution limit");
-            return Err(LendingError::BorrowTooLarge.into());
-        }
-
-        deposit.attributed_borrow_value = deposit
-            .attributed_borrow_value
-            .try_add(additional_borrow_attributed)?;
-
-        if deposit_reserve_info.key != borrow_reserve_info.key {
-            Reserve::pack(reserve, &mut deposit_reserve_info.data.borrow_mut())?;
-        }
-    }
-
     LendingMarket::pack(lending_market, &mut lending_market_info.data.borrow_mut())?;
 
     borrow_reserve.liquidity.borrow(borrow_amount)?;
     borrow_reserve.last_update.mark_stale();
+
+    obligation.borrowed_value = obligation
+        .borrowed_value
+        .try_add(borrow_reserve.market_value(borrow_amount)?)?;
+
     Reserve::pack(*borrow_reserve, &mut borrow_reserve_info.data.borrow_mut())?;
 
     let obligation_liquidity = obligation
@@ -1877,6 +1837,13 @@ fn process_borrow_obligation_liquidity(
 
     obligation_liquidity.borrow(borrow_amount)?;
     obligation.last_update.mark_stale();
+
+    update_borrow_attribution_values(&mut obligation, &accounts[9..])?;
+    // HACK: fast forward through the used account info's
+    for _ in 0..obligation.deposits.len() {
+        next_account_info(account_info_iter)?;
+    }
+
     Obligation::pack(obligation, &mut obligation_info.data.borrow_mut())?;
 
     let mut owner_fee = borrow_fee;

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1194,9 +1194,11 @@ fn update_borrow_attribution_values(
             return Err(LendingError::InvalidAccountInput.into());
         }
 
-        deposit_reserve.attributed_borrow_value = deposit_reserve
-            .attributed_borrow_value
-            .saturating_sub(collateral.attributed_borrow_value);
+        if obligation.updated_borrow_attribution_after_upgrade {
+            deposit_reserve.attributed_borrow_value = deposit_reserve
+                .attributed_borrow_value
+                .saturating_sub(collateral.attributed_borrow_value);
+        }
 
         if obligation.deposited_value > Decimal::zero() {
             collateral.attributed_borrow_value = collateral
@@ -1225,6 +1227,8 @@ fn update_borrow_attribution_values(
 
         Reserve::pack(deposit_reserve, &mut deposit_reserve_info.data.borrow_mut())?;
     }
+
+    obligation.updated_borrow_attribution_after_upgrade = true;
 
     Ok(())
 }

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1148,7 +1148,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
     obligation.last_update.update_slot(clock.slot);
 
-    update_borrow_attribution_values(&mut obligation, &accounts[1..])?;
+    update_borrow_attribution_values(&mut obligation, &accounts[1..], false)?;
 
     // move the ObligationLiquidity with the max borrow weight to the front
     if let Some((_, max_borrow_weight_index)) = max_borrow_weight {
@@ -1180,6 +1180,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 fn update_borrow_attribution_values(
     obligation: &mut Obligation,
     deposit_reserve_infos: &[AccountInfo],
+    error_if_limit_exceeded: bool,
 ) -> ProgramResult {
     let deposit_infos = &mut deposit_reserve_infos.iter();
 
@@ -1210,8 +1211,9 @@ fn update_borrow_attribution_values(
             .attributed_borrow_value
             .try_add(collateral.attributed_borrow_value)?;
 
-        if deposit_reserve.attributed_borrow_value
-            > Decimal::from(deposit_reserve.config.attributed_borrow_limit)
+        if error_if_limit_exceeded
+            && deposit_reserve.attributed_borrow_value
+                > Decimal::from(deposit_reserve.config.attributed_borrow_limit)
         {
             msg!(
                 "Attributed borrow value is over the limit for reserve {} and mint {}",
@@ -1611,7 +1613,7 @@ fn _withdraw_obligation_collateral<'a>(
         .market_value
         .saturating_sub(withdraw_value);
 
-    update_borrow_attribution_values(&mut obligation, deposit_reserve_infos)?;
+    update_borrow_attribution_values(&mut obligation, deposit_reserve_infos, true)?;
 
     // obligation.withdraw must be called after updating borrow attribution values, since we can
     // lose information if an entire deposit is removed, making the former calculation incorrect
@@ -1866,7 +1868,7 @@ fn process_borrow_obligation_liquidity(
     obligation_liquidity.borrow(borrow_amount)?;
     obligation.last_update.mark_stale();
 
-    update_borrow_attribution_values(&mut obligation, &accounts[9..])?;
+    update_borrow_attribution_values(&mut obligation, &accounts[9..], true)?;
     // HACK: fast forward through the used account info's
     for _ in 0..obligation.deposits.len() {
         next_account_info(account_info_iter)?;

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1149,7 +1149,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     let deposit_infos = &mut accounts.iter().skip(1);
 
     // attributed borrow calculation
-    for (index, collateral) in obligation.deposits.iter_mut().enumerate() {
+    for (_index, collateral) in obligation.deposits.iter_mut().enumerate() {
         let deposit_reserve_info = next_account_info(deposit_infos)?;
         let mut deposit_reserve = Reserve::unpack(&deposit_reserve_info.data.borrow())?;
 

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1809,7 +1809,7 @@ fn process_borrow_obligation_liquidity(
         let mut reserve = Reserve::unpack(&deposit_reserve_info.data.borrow())?;
 
         // edge case. if the deposit reserve == borrow reserve, we need to use the already loaded
-        // borrow reserve instead of unpacking it again, otherwise we'll lose data.
+        // borrow reserve instead of unpacking it again, otherwise we'll lose prior changes
         let deposit_reserve = if deposit_reserve_info.key != borrow_reserve_info.key {
             &mut reserve
         } else {

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1457,6 +1457,7 @@ fn process_withdraw_obligation_collateral(
         clock,
         token_program_id,
         false,
+        &accounts[8..],
     )?;
     Ok(())
 }
@@ -1475,6 +1476,7 @@ fn _withdraw_obligation_collateral<'a>(
     clock: &Clock,
     token_program_id: &AccountInfo<'a>,
     account_for_rate_limiter: bool,
+    deposit_reserve_infos: &[AccountInfo],
 ) -> Result<u64, ProgramError> {
     let lending_market = LendingMarket::unpack(&lending_market_info.data.borrow())?;
     if lending_market_info.owner != program_id {
@@ -1595,8 +1597,26 @@ fn _withdraw_obligation_collateral<'a>(
         return Err(LendingError::WithdrawTooLarge.into());
     }
 
+    let withdraw_value = withdraw_reserve.market_value(
+        withdraw_reserve
+            .collateral_exchange_rate()?
+            .decimal_collateral_to_liquidity(Decimal::from(withdraw_amount))?,
+    )?;
+
+    // update relevant values before updating borrow attribution values
+    obligation.deposited_value = obligation.deposited_value.saturating_sub(withdraw_value);
+
+    obligation.deposits[collateral_index].market_value = obligation.deposits[collateral_index]
+        .market_value
+        .saturating_sub(withdraw_value);
+
+    update_borrow_attribution_values(&mut obligation, deposit_reserve_infos)?;
+
+    // obligation.withdraw must be called after updating borrow attribution values, since we can
+    // lose information if an entire deposit is removed, making the former calculation incorrect
     obligation.withdraw(withdraw_amount, collateral_index)?;
     obligation.last_update.mark_stale();
+
     Obligation::pack(obligation, &mut obligation_info.data.borrow_mut())?;
 
     spl_token_transfer(TokenTransferParams {
@@ -2316,6 +2336,7 @@ fn process_withdraw_obligation_collateral_and_redeem_reserve_liquidity(
         clock,
         token_program_id,
         true,
+        &accounts[12..],
     )?;
 
     _redeem_reserve_collateral(

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -36,10 +36,10 @@ use solana_program::{
 };
 
 use solend_sdk::{
+    math::SaturatingSub,
     oracles::{
         get_oracle_type, get_pyth_price_unchecked, validate_pyth_price_account_info, OracleType,
     },
-    math::SaturatingSub,
     state::{LendingMarketMetadata, RateLimiter, RateLimiterConfig, ReserveType},
 };
 use solend_sdk::{switchboard_v2_devnet, switchboard_v2_mainnet};

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1002,7 +1002,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
     let mut deposited_value = Decimal::zero();
     let mut borrowed_value = Decimal::zero(); // weighted borrow value wrt borrow weights
-    let mut true_borrowed_value = Decimal::zero();
+    let mut unweighted_borrowed_value = Decimal::zero();
     let mut borrowed_value_upper_bound = Decimal::zero();
     let mut allowed_borrow_value = Decimal::zero();
     let mut unhealthy_borrow_value = Decimal::zero();
@@ -1124,7 +1124,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
             borrowed_value.try_add(market_value.try_mul(borrow_reserve.borrow_weight())?)?;
         borrowed_value_upper_bound = borrowed_value_upper_bound
             .try_add(market_value_upper_bound.try_mul(borrow_reserve.borrow_weight())?)?;
-        true_borrowed_value = true_borrowed_value.try_add(market_value)?;
+        unweighted_borrowed_value = unweighted_borrowed_value.try_add(market_value)?;
     }
 
     if account_info_iter.peek().is_some() {
@@ -1134,7 +1134,7 @@ fn process_refresh_obligation(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
     obligation.deposited_value = deposited_value;
     obligation.borrowed_value = borrowed_value;
-    obligation.true_borrowed_value = true_borrowed_value;
+    obligation.unweighted_borrowed_value = unweighted_borrowed_value;
     obligation.borrowed_value_upper_bound = borrowed_value_upper_bound;
     obligation.borrowing_isolated_asset = borrowing_isolated_asset;
 
@@ -1201,7 +1201,7 @@ fn update_borrow_attribution_values(
         if obligation.deposited_value > Decimal::zero() {
             collateral.attributed_borrow_value = collateral
                 .market_value
-                .try_mul(obligation.true_borrowed_value)?
+                .try_mul(obligation.unweighted_borrowed_value)?
                 .try_div(obligation.deposited_value)?
         } else {
             collateral.attributed_borrow_value = Decimal::zero();
@@ -1856,8 +1856,8 @@ fn process_borrow_obligation_liquidity(
             .try_mul(borrow_reserve.borrow_weight())?,
     )?;
 
-    obligation.true_borrowed_value = obligation
-        .true_borrowed_value
+    obligation.unweighted_borrowed_value = obligation
+        .unweighted_borrowed_value
         .try_add(borrow_reserve.market_value(borrow_amount)?)?;
 
     Reserve::pack(*borrow_reserve, &mut borrow_reserve_info.data.borrow_mut())?;

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -207,7 +207,6 @@ async fn test_calculations() {
         .await
         .unwrap();
 
-
     // check both reserves before refresh, since the borrow attribution values should have been
     // updated
     {

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-bpf")]
 
-use solend_program::math::TryDiv;
 use crate::solend_program_test::custom_scenario;
+use solend_program::math::TryDiv;
 
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
@@ -536,7 +536,9 @@ async fn test_withdraw() {
         let usdc_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
         assert_eq!(
             usdc_reserve_post.account.attributed_borrow_value,
-            Decimal::from(7500u64).try_div(Decimal::from(1000u64)).unwrap()
+            Decimal::from(7500u64)
+                .try_div(Decimal::from(1000u64))
+                .unwrap()
         );
 
         let wsol_reserve_post = test.load_account::<Reserve>(reserves[1].pubkey).await;
@@ -548,11 +550,15 @@ async fn test_withdraw() {
         let obligation_post = test.load_account::<Obligation>(obligations[0].pubkey).await;
         assert_eq!(
             obligation_post.account.deposits[0].attributed_borrow_value,
-            Decimal::from(7500u64).try_div(Decimal::from(1000u64)).unwrap()
+            Decimal::from(7500u64)
+                .try_div(Decimal::from(1000u64))
+                .unwrap()
         );
         assert_eq!(
             obligation_post.account.deposits[1].attributed_borrow_value,
-            Decimal::from(2500u64).try_div(Decimal::from(1000u64)).unwrap()
+            Decimal::from(2500u64)
+                .try_div(Decimal::from(1000u64))
+                .unwrap()
         );
     }
 

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -29,6 +29,144 @@ use helpers::*;
 use solana_program_test::*;
 
 #[tokio::test]
+async fn test_refresh_obligation() {
+    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 80,
+                        liquidation_threshold: 81,
+                        max_liquidation_threshold: 82,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 80,
+                        liquidation_threshold: 81,
+                        max_liquidation_threshold: 82,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[
+                ObligationArgs {
+                    deposits: vec![
+                        (usdc_mint::id(), 80 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                    ],
+                    borrows: vec![
+                        (usdc_mint::id(), 10 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), LAMPORTS_PER_SOL),
+                    ],
+                },
+                ObligationArgs {
+                    deposits: vec![
+                        (usdc_mint::id(), 400 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 10 * LAMPORTS_PER_SOL),
+                    ],
+                    borrows: vec![
+                        (usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                    ],
+                },
+            ],
+        )
+        .await;
+
+    // check initial borrow attribution values
+    // obligation 0
+    // usdc.borrow_attribution = 80 / 100 * 20 = 16
+    assert_eq!(
+        obligations[0].account.deposits[0].attributed_borrow_value,
+        Decimal::from(16u64)
+    );
+    // wsol.borrow_attribution = 20 / 100 * 20 = 4
+    assert_eq!(
+        obligations[0].account.deposits[1].attributed_borrow_value,
+        Decimal::from(4u64)
+    );
+
+    // obligation 1
+    // usdc.borrow_attribution = 400 / 500 * 120 = 96
+    assert_eq!(
+        obligations[1].account.deposits[0].attributed_borrow_value,
+        Decimal::from(96u64)
+    );
+    // wsol.borrow_attribution = 100 / 500 * 120 = 24
+    assert_eq!(
+        obligations[1].account.deposits[1].attributed_borrow_value,
+        Decimal::from(24u64)
+    );
+
+    // usdc reserve: 16 + 96 = 112
+    assert_eq!(
+        reserves[0].account.attributed_borrow_value,
+        Decimal::from(112u64)
+    );
+    // wsol reserve: 4 + 24 = 28
+    assert_eq!(
+        reserves[1].account.attributed_borrow_value,
+        Decimal::from(28u64)
+    );
+
+    // change borrow attribution limit, check that it's applied
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &reserves[0],
+            ReserveConfig {
+                attributed_borrow_limit: 1,
+                ..reserves[0].account.config
+            },
+            reserves[0].account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    // make sure it doesn't error
+    lending_market
+        .refresh_obligation(&mut test, &obligations[0])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn test_calculations() {
     let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
         custom_scenario(

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,17 +1,10 @@
 #![cfg(feature = "test-bpf")]
 
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
-use solend_sdk::instruction::refresh_obligation;
-
 use crate::solend_program_test::custom_scenario;
-use crate::solend_program_test::SolendProgramTest;
+
 use crate::solend_program_test::User;
-use solana_sdk::pubkey::Pubkey;
+
 use solend_program::math::TryDiv;
-use solend_program::processor::process_instruction;
-use solend_sdk::state::ObligationCollateral;
-use solend_sdk::state::ObligationLiquidity;
-use solend_sdk::state::PROGRAM_VERSION;
 
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
@@ -157,7 +150,7 @@ async fn test_refresh_obligation() {
             &lending_market_owner,
             &reserves[0],
             ReserveConfig {
-                attributed_borrow_limit: 1,
+                attributed_borrow_limit_open: 1,
                 ..reserves[0].account.config
             },
             reserves[0].account.rate_limiter.config,
@@ -295,7 +288,7 @@ async fn test_calculations() {
             &lending_market_owner,
             &reserves[0],
             ReserveConfig {
-                attributed_borrow_limit: 113,
+                attributed_borrow_limit_open: 113,
                 ..reserves[0].account.config
             },
             reserves[0].account.rate_limiter.config,
@@ -333,7 +326,7 @@ async fn test_calculations() {
             &lending_market_owner,
             &reserves[0],
             ReserveConfig {
-                attributed_borrow_limit: 120,
+                attributed_borrow_limit_open: 120,
                 ..reserves[0].account.config
             },
             reserves[0].account.rate_limiter.config,
@@ -386,7 +379,7 @@ async fn test_calculations() {
             },
             attributed_borrow_value: Decimal::from(120u64),
             config: ReserveConfig {
-                attributed_borrow_limit: 120,
+                attributed_borrow_limit_open: 120,
                 ..usdc_reserve.config
             },
             ..usdc_reserve
@@ -619,7 +612,7 @@ async fn test_withdraw() {
             &lending_market_owner,
             &reserves[0],
             ReserveConfig {
-                attributed_borrow_limit: 6,
+                attributed_borrow_limit_open: 6,
                 ..reserves[0].account.config
             },
             reserves[0].account.rate_limiter.config,
@@ -656,7 +649,7 @@ async fn test_withdraw() {
             &lending_market_owner,
             &reserves[0],
             ReserveConfig {
-                attributed_borrow_limit: 10,
+                attributed_borrow_limit_open: 10,
                 ..reserves[0].account.config
             },
             reserves[0].account.rate_limiter.config,
@@ -858,117 +851,5 @@ async fn test_liquidate() {
     assert_eq!(
         usdc_reserve_post.account.attributed_borrow_value,
         Decimal::zero()
-    );
-}
-
-#[tokio::test]
-async fn test_calculation_on_program_upgrade() {
-    let mut test = ProgramTest::new(
-        "solend_program",
-        solend_program::id(),
-        processor!(process_instruction),
-    );
-
-    let reserve_1 = Reserve {
-        version: PROGRAM_VERSION,
-        last_update: LastUpdate {
-            slot: 1,
-            stale: false,
-        },
-        attributed_borrow_value: Decimal::from(10u64),
-        liquidity: ReserveLiquidity {
-            market_price: Decimal::from(10u64),
-            mint_decimals: 0,
-            ..ReserveLiquidity::default()
-        },
-        ..Reserve::default()
-    };
-    let reserve_1_pubkey = Pubkey::new_unique();
-
-    test.add_packable_account(
-        reserve_1_pubkey,
-        u32::MAX as u64,
-        &reserve_1,
-        &solend_program::id(),
-    );
-
-    let reserve_2 = Reserve {
-        version: PROGRAM_VERSION,
-        last_update: LastUpdate {
-            slot: 1,
-            stale: false,
-        },
-        liquidity: ReserveLiquidity {
-            market_price: Decimal::from(10u64),
-            mint_decimals: 0,
-            ..ReserveLiquidity::default()
-        },
-        ..Reserve::default()
-    };
-    let reserve_2_pubkey = Pubkey::new_unique();
-    test.add_packable_account(
-        reserve_2_pubkey,
-        u32::MAX as u64,
-        &reserve_2,
-        &solend_program::id(),
-    );
-
-    let obligation_pubkey = Pubkey::new_unique();
-    let obligation = Obligation {
-        version: PROGRAM_VERSION,
-        deposits: vec![ObligationCollateral {
-            deposit_reserve: reserve_1_pubkey,
-            deposited_amount: 2u64,
-            market_value: Decimal::from(20u64),
-            attributed_borrow_value: Decimal::from(10u64),
-        }],
-        borrows: vec![ObligationLiquidity {
-            borrow_reserve: reserve_2_pubkey,
-            borrowed_amount_wads: Decimal::from(1u64),
-            ..ObligationLiquidity::default()
-        }],
-        updated_borrow_attribution_after_upgrade: false,
-        ..Obligation::default()
-    };
-
-    test.add_packable_account(
-        obligation_pubkey,
-        u32::MAX as u64,
-        &obligation,
-        &solend_program::id(),
-    );
-
-    let mut test = SolendProgramTest::start_with_test(test).await;
-
-    let ix = [refresh_obligation(
-        solend_program::id(),
-        obligation_pubkey,
-        vec![reserve_1_pubkey, reserve_2_pubkey],
-    )];
-
-    test.process_transaction(&ix, None).await.unwrap();
-
-    let reserve_1 = test.load_account::<Reserve>(reserve_1_pubkey).await;
-    assert_eq!(
-        reserve_1.account.attributed_borrow_value,
-        Decimal::from(20u64)
-    );
-
-    // run it again, this time make sure the borrow attribution value gets correctly subtracted
-    let ix = [
-        ComputeBudgetInstruction::set_compute_unit_price(1),
-        refresh_obligation(
-            solend_program::id(),
-            obligation_pubkey,
-            vec![reserve_1_pubkey, reserve_2_pubkey],
-        ),
-    ];
-
-    test.process_transaction(&ix, None).await.unwrap();
-
-    let reserve_1 = test.load_account::<Reserve>(reserve_1_pubkey).await;
-    assert_eq!(
-        reserve_1.account.attributed_borrow_value,
-        Decimal::from(20u64)
     );
 }

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,7 +1,13 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::solend_program_test::custom_scenario;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::math::TryAdd;
+use solend_program::state::LastUpdate;
 use solend_program::state::Reserve;
+use solend_sdk::error::LendingError;
+use solend_sdk::state::ReserveLiquidity;
 
 use crate::solend_program_test::ObligationArgs;
 use crate::solend_program_test::PriceArgs;
@@ -21,79 +27,80 @@ use solana_program_test::*;
 
 #[tokio::test]
 async fn test_calculations() {
-    let (mut test, lending_market, reserves, obligations, users, _) = custom_scenario(
-        &[
-            ReserveArgs {
-                mint: usdc_mint::id(),
-                config: ReserveConfig {
-                    loan_to_value_ratio: 80,
-                    liquidation_threshold: 81,
-                    max_liquidation_threshold: 82,
-                    fees: ReserveFees {
-                        host_fee_percentage: 0,
-                        ..ReserveFees::default()
+    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 80,
+                        liquidation_threshold: 81,
+                        max_liquidation_threshold: 82,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
                     },
-                    optimal_borrow_rate: 0,
-                    max_borrow_rate: 0,
-                    ..test_reserve_config()
-                },
-                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
-                price: PriceArgs {
-                    price: 10,
-                    conf: 0,
-                    expo: -1,
-                    ema_price: 10,
-                    ema_conf: 1,
-                },
-            },
-            ReserveArgs {
-                mint: wsol_mint::id(),
-                config: ReserveConfig {
-                    loan_to_value_ratio: 80,
-                    liquidation_threshold: 81,
-                    max_liquidation_threshold: 82,
-                    fees: ReserveFees {
-                        host_fee_percentage: 0,
-                        ..ReserveFees::default()
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
                     },
-                    optimal_borrow_rate: 0,
-                    max_borrow_rate: 0,
-                    ..test_reserve_config()
                 },
-                liquidity_amount: 100 * LAMPORTS_PER_SOL,
-                price: PriceArgs {
-                    price: 10,
-                    conf: 0,
-                    expo: 0,
-                    ema_price: 10,
-                    ema_conf: 0,
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: ReserveConfig {
+                        loan_to_value_ratio: 80,
+                        liquidation_threshold: 81,
+                        max_liquidation_threshold: 82,
+                        fees: ReserveFees {
+                            host_fee_percentage: 0,
+                            ..ReserveFees::default()
+                        },
+                        optimal_borrow_rate: 0,
+                        max_borrow_rate: 0,
+                        ..test_reserve_config()
+                    },
+                    liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
                 },
-            },
-        ],
-        &[
-            ObligationArgs {
-                deposits: vec![
-                    (usdc_mint::id(), 80 * FRACTIONAL_TO_USDC),
-                    (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
-                ],
-                borrows: vec![
-                    (usdc_mint::id(), 10 * FRACTIONAL_TO_USDC),
-                    (wsol_mint::id(), LAMPORTS_PER_SOL),
-                ],
-            },
-            ObligationArgs {
-                deposits: vec![
-                    (usdc_mint::id(), 400 * FRACTIONAL_TO_USDC),
-                    (wsol_mint::id(), 10 * LAMPORTS_PER_SOL),
-                ],
-                borrows: vec![
-                    (usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
-                    (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
-                ],
-            },
-        ],
-    )
-    .await;
+            ],
+            &[
+                ObligationArgs {
+                    deposits: vec![
+                        (usdc_mint::id(), 80 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                    ],
+                    borrows: vec![
+                        (usdc_mint::id(), 10 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), LAMPORTS_PER_SOL),
+                    ],
+                },
+                ObligationArgs {
+                    deposits: vec![
+                        (usdc_mint::id(), 400 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 10 * LAMPORTS_PER_SOL),
+                    ],
+                    borrows: vec![
+                        (usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
+                        (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                    ],
+                },
+            ],
+        )
+        .await;
 
     // check initial borrow attribution values
     // obligation 0
@@ -131,7 +138,63 @@ async fn test_calculations() {
         Decimal::from(28u64)
     );
 
-    // borrow another 10 usd from obligation 0
+    // change borrow attribution limit, check that it's applied
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &reserves[0],
+            ReserveConfig {
+                attributed_borrow_limit: 113,
+                ..reserves[0].account.config
+            },
+            reserves[0].account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // attempt to borrow another 10 usd from obligation 0, this should fail
+    let err = lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            &reserves[0],
+            &obligations[0],
+            &users[0],
+            None,
+            10 * FRACTIONAL_TO_USDC,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(LendingError::BorrowTooLarge as u32)
+        )
+    );
+
+    // change borrow attribution limit so that the borrow will succeed
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &reserves[0],
+            ReserveConfig {
+                attributed_borrow_limit: 120,
+                ..reserves[0].account.config
+            },
+            reserves[0].account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    // attempt to borrow another 10 usd from obligation 0, this should pass now
     lending_market
         .borrow_obligation_liquidity(
             &mut test,
@@ -144,7 +207,49 @@ async fn test_calculations() {
         .await
         .unwrap();
 
-    test.advance_clock_by_slots(1).await;
+
+    // check both reserves before refresh, since the borrow attribution values should have been
+    // updated
+    {
+        let usdc_reserve = reserves[0].account.clone();
+        let usdc_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
+        let expected_usdc_reserve_post = Reserve {
+            last_update: LastUpdate {
+                slot: 1001,
+                stale: true,
+            },
+            liquidity: ReserveLiquidity {
+                available_amount: usdc_reserve.liquidity.available_amount - 10 * FRACTIONAL_TO_USDC,
+                borrowed_amount_wads: usdc_reserve
+                    .liquidity
+                    .borrowed_amount_wads
+                    .try_add(Decimal::from(10 * FRACTIONAL_TO_USDC))
+                    .unwrap(),
+                ..usdc_reserve.liquidity
+            },
+            rate_limiter: {
+                let mut rate_limiter = usdc_reserve.rate_limiter;
+                rate_limiter
+                    .update(1000, Decimal::from(10 * FRACTIONAL_TO_USDC))
+                    .unwrap();
+
+                rate_limiter
+            },
+            attributed_borrow_value: Decimal::from(120u64),
+            config: ReserveConfig {
+                attributed_borrow_limit: 120,
+                ..usdc_reserve.config
+            },
+            ..usdc_reserve
+        };
+        assert_eq!(usdc_reserve_post.account, expected_usdc_reserve_post);
+
+        let wsol_reserve_post = test.load_account::<Reserve>(reserves[1].pubkey).await;
+        assert_eq!(
+            wsol_reserve_post.account.attributed_borrow_value,
+            Decimal::from(30u64)
+        );
+    }
 
     lending_market
         .refresh_obligation(&mut test, &obligations[0])

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::solend_program_test::custom_scenario;
-use crate::solend_program_test::User;
 
-use log::info;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
 use solend_program::math::TryAdd;
@@ -175,7 +173,7 @@ async fn test_calculations() {
         err,
         TransactionError::InstructionError(
             1,
-            InstructionError::Custom(LendingError::BorrowTooLarge as u32)
+            InstructionError::Custom(LendingError::BorrowAttributionLimitExceeded as u32)
         )
     );
 
@@ -286,117 +284,117 @@ async fn test_calculations() {
     );
 }
 
-#[tokio::test]
-async fn benchmark() {
-    // setup
-    let reserve_arg = ReserveArgs {
-        mint: usdc_mint::id(),
-        config: ReserveConfig {
-            loan_to_value_ratio: 80,
-            liquidation_threshold: 81,
-            max_liquidation_threshold: 82,
-            fees: ReserveFees {
-                host_fee_percentage: 0,
-                ..ReserveFees::default()
-            },
-            optimal_borrow_rate: 0,
-            max_borrow_rate: 0,
-            ..test_reserve_config()
-        },
-        liquidity_amount: 100 * FRACTIONAL_TO_USDC,
-        price: PriceArgs {
-            price: 10,
-            conf: 0,
-            expo: -1,
-            ema_price: 10,
-            ema_conf: 1,
-        },
-    };
+// #[tokio::test]
+// async fn benchmark() {
+//     // setup
+//     let reserve_arg = ReserveArgs {
+//         mint: usdc_mint::id(),
+//         config: ReserveConfig {
+//             loan_to_value_ratio: 80,
+//             liquidation_threshold: 81,
+//             max_liquidation_threshold: 82,
+//             fees: ReserveFees {
+//                 host_fee_percentage: 0,
+//                 ..ReserveFees::default()
+//             },
+//             optimal_borrow_rate: 0,
+//             max_borrow_rate: 0,
+//             ..test_reserve_config()
+//         },
+//         liquidity_amount: 100 * FRACTIONAL_TO_USDC,
+//         price: PriceArgs {
+//             price: 10,
+//             conf: 0,
+//             expo: -1,
+//             ema_price: 10,
+//             ema_conf: 1,
+//         },
+//     };
 
-    let reserve_args = vec![reserve_arg; 9];
+//     let reserve_args = vec![reserve_arg; 9];
 
-    let obligation_args = ObligationArgs {
-        deposits: vec![],
-        borrows: vec![],
-    };
+//     let obligation_args = ObligationArgs {
+//         deposits: vec![],
+//         borrows: vec![],
+//     };
 
-    let (mut test, lending_market, reserves, obligations, mut users, _lending_market_owner) =
-        custom_scenario(&reserve_args, &[obligation_args]).await;
+//     let (mut test, lending_market, reserves, obligations, mut users, _lending_market_owner) =
+//         custom_scenario(&reserve_args, &[obligation_args]).await;
 
-    let user = User::new_with_balances(
-        &mut test,
-        &[(&usdc_mint::id(), 100_000 * FRACTIONAL_TO_USDC)],
-    )
-    .await;
+//     let user = User::new_with_balances(
+//         &mut test,
+//         &[(&usdc_mint::id(), 100_000 * FRACTIONAL_TO_USDC)],
+//     )
+//     .await;
 
-    user.transfer(
-        &usdc_mint::id(),
-        users[0].get_account(&usdc_mint::id()).unwrap(),
-        100_000 * FRACTIONAL_TO_USDC,
-        &mut test,
-    )
-    .await;
+//     user.transfer(
+//         &usdc_mint::id(),
+//         users[0].get_account(&usdc_mint::id()).unwrap(),
+//         100_000 * FRACTIONAL_TO_USDC,
+//         &mut test,
+//     )
+//     .await;
 
-    test.advance_clock_by_slots(1).await;
+//     test.advance_clock_by_slots(1).await;
 
-    for reserve in &reserves {
-        users[0]
-            .create_token_account(&reserve.account.collateral.mint_pubkey, &mut test)
-            .await;
+//     for reserve in &reserves {
+//         users[0]
+//             .create_token_account(&reserve.account.collateral.mint_pubkey, &mut test)
+//             .await;
 
-        lending_market
-            .deposit_reserve_liquidity_and_obligation_collateral(
-                &mut test,
-                reserve,
-                &obligations[0],
-                &users[0],
-                10 * FRACTIONAL_TO_USDC,
-            )
-            .await
-            .unwrap();
+//         lending_market
+//             .deposit_reserve_liquidity_and_obligation_collateral(
+//                 &mut test,
+//                 reserve,
+//                 &obligations[0],
+//                 &users[0],
+//                 10 * FRACTIONAL_TO_USDC,
+//             )
+//             .await
+//             .unwrap();
 
-        test.advance_clock_by_slots(1).await;
-    }
+//         test.advance_clock_by_slots(1).await;
+//     }
 
-    lending_market
-        .borrow_obligation_liquidity(
-            &mut test,
-            &reserves[0],
-            &obligations[0],
-            &users[0],
-            None,
-            FRACTIONAL_TO_USDC,
-        )
-        .await
-        .unwrap();
+//     lending_market
+//         .borrow_obligation_liquidity(
+//             &mut test,
+//             &reserves[0],
+//             &obligations[0],
+//             &users[0],
+//             None,
+//             FRACTIONAL_TO_USDC,
+//         )
+//         .await
+//         .unwrap();
 
-    info!("Starting benchmark");
-    // lending_market
-    //     .refresh_obligation(&mut test, &obligations[0])
-    //     .await
-    //     .unwrap();
+//     info!("Starting benchmark");
+//     // lending_market
+//     //     .refresh_obligation(&mut test, &obligations[0])
+//     //     .await
+//     //     .unwrap();
 
-    // test.advance_clock_by_slots(1).await;
+//     // test.advance_clock_by_slots(1).await;
 
-    for reserve in reserves.iter().skip(1).rev() {
-        lending_market
-            .withdraw_obligation_collateral_and_redeem_reserve_collateral(
-                &mut test,
-                reserve,
-                &obligations[0],
-                &users[0],
-                u64::MAX,
-            )
-            .await
-            .unwrap();
+//     for reserve in reserves.iter().skip(1).rev() {
+//         lending_market
+//             .withdraw_obligation_collateral_and_redeem_reserve_collateral(
+//                 &mut test,
+//                 reserve,
+//                 &obligations[0],
+//                 &users[0],
+//                 u64::MAX,
+//             )
+//             .await
+//             .unwrap();
 
-        test.advance_clock_by_slots(1).await;
-    }
+//         test.advance_clock_by_slots(1).await;
+//     }
 
-    lending_market
-        .refresh_obligation(&mut test, &obligations[0])
-        .await
-        .unwrap();
+//     lending_market
+//         .refresh_obligation(&mut test, &obligations[0])
+//         .await
+//         .unwrap();
 
-    test.advance_clock_by_slots(1).await;
-}
+//     test.advance_clock_by_slots(1).await;
+// }

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -2,8 +2,7 @@
 
 use crate::solend_program_test::custom_scenario;
 use crate::solend_program_test::User;
-use crate::tokio::time::sleep;
-use crate::tokio::time::Duration;
+
 use log::info;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
@@ -321,7 +320,7 @@ async fn benchmark() {
         borrows: vec![],
     };
 
-    let (mut test, lending_market, reserves, obligations, mut users, lending_market_owner) =
+    let (mut test, lending_market, reserves, obligations, mut users, _lending_market_owner) =
         custom_scenario(&reserve_args, &[obligation_args]).await;
 
     let user = User::new_with_balances(

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,22 +1,17 @@
 #![cfg(feature = "test-bpf")]
 
-use solend_program::state::Reserve;
 use crate::solend_program_test::custom_scenario;
-use solend_program::state::ObligationCollateral;
+use solend_program::state::Reserve;
 
 use crate::solend_program_test::ObligationArgs;
 use crate::solend_program_test::PriceArgs;
 use crate::solend_program_test::ReserveArgs;
 
 use solana_program::native_token::LAMPORTS_PER_SOL;
-use solana_sdk::instruction::InstructionError;
-use solana_sdk::transaction::TransactionError;
-use solend_program::error::LendingError;
+
 use solend_sdk::math::Decimal;
 
-use solend_program::state::LastUpdate;
-use solend_program::state::ReserveType;
-use solend_program::state::{Obligation, ObligationLiquidity, ReserveConfig};
+use solend_program::state::{Obligation, ReserveConfig};
 
 use solend_sdk::state::ReserveFees;
 mod helpers;

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,0 +1,185 @@
+#![cfg(feature = "test-bpf")]
+
+use solend_program::state::Reserve;
+use crate::solend_program_test::custom_scenario;
+use solend_program::state::ObligationCollateral;
+
+use crate::solend_program_test::ObligationArgs;
+use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
+
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+use solend_sdk::math::Decimal;
+
+use solend_program::state::LastUpdate;
+use solend_program::state::ReserveType;
+use solend_program::state::{Obligation, ObligationLiquidity, ReserveConfig};
+
+use solend_sdk::state::ReserveFees;
+mod helpers;
+
+use helpers::*;
+use solana_program_test::*;
+
+#[tokio::test]
+async fn test_calculations() {
+    let (mut test, lending_market, reserves, obligations, users, _) = custom_scenario(
+        &[
+            ReserveArgs {
+                mint: usdc_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 80,
+                    liquidation_threshold: 81,
+                    max_liquidation_threshold: 82,
+                    fees: ReserveFees {
+                        host_fee_percentage: 0,
+                        ..ReserveFees::default()
+                    },
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: -1,
+                    ema_price: 10,
+                    ema_conf: 1,
+                },
+            },
+            ReserveArgs {
+                mint: wsol_mint::id(),
+                config: ReserveConfig {
+                    loan_to_value_ratio: 80,
+                    liquidation_threshold: 81,
+                    max_liquidation_threshold: 82,
+                    fees: ReserveFees {
+                        host_fee_percentage: 0,
+                        ..ReserveFees::default()
+                    },
+                    optimal_borrow_rate: 0,
+                    max_borrow_rate: 0,
+                    ..test_reserve_config()
+                },
+                liquidity_amount: 100 * LAMPORTS_PER_SOL,
+                price: PriceArgs {
+                    price: 10,
+                    conf: 0,
+                    expo: 0,
+                    ema_price: 10,
+                    ema_conf: 0,
+                },
+            },
+        ],
+        &[
+            ObligationArgs {
+                deposits: vec![
+                    (usdc_mint::id(), 80 * FRACTIONAL_TO_USDC),
+                    (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                ],
+                borrows: vec![
+                    (usdc_mint::id(), 10 * FRACTIONAL_TO_USDC),
+                    (wsol_mint::id(), LAMPORTS_PER_SOL),
+                ],
+            },
+            ObligationArgs {
+                deposits: vec![
+                    (usdc_mint::id(), 400 * FRACTIONAL_TO_USDC),
+                    (wsol_mint::id(), 10 * LAMPORTS_PER_SOL),
+                ],
+                borrows: vec![
+                    (usdc_mint::id(), 100 * FRACTIONAL_TO_USDC),
+                    (wsol_mint::id(), 2 * LAMPORTS_PER_SOL),
+                ],
+            },
+        ],
+    )
+    .await;
+
+    // check initial borrow attribution values
+    // obligation 0
+    // usdc.borrow_attribution = 80 / 100 * 20 = 16
+    assert_eq!(
+        obligations[0].account.deposits[0].attributed_borrow_value,
+        Decimal::from(16u64)
+    );
+    // wsol.borrow_attribution = 20 / 100 * 20 = 4
+    assert_eq!(
+        obligations[0].account.deposits[1].attributed_borrow_value,
+        Decimal::from(4u64)
+    );
+
+    // obligation 1
+    // usdc.borrow_attribution = 400 / 500 * 120 = 96
+    assert_eq!(
+        obligations[1].account.deposits[0].attributed_borrow_value,
+        Decimal::from(96u64)
+    );
+    // wsol.borrow_attribution = 100 / 500 * 120 = 24
+    assert_eq!(
+        obligations[1].account.deposits[1].attributed_borrow_value,
+        Decimal::from(24u64)
+    );
+
+    // usdc reserve: 16 + 96 = 112
+    assert_eq!(
+        reserves[0].account.attributed_borrow_value,
+        Decimal::from(112u64)
+    );
+    // wsol reserve: 4 + 24 = 28
+    assert_eq!(
+        reserves[1].account.attributed_borrow_value,
+        Decimal::from(28u64)
+    );
+
+    // borrow another 10 usd from obligation 0
+    lending_market
+        .borrow_obligation_liquidity(
+            &mut test,
+            &reserves[0],
+            &obligations[0],
+            &users[0],
+            None,
+            10 * FRACTIONAL_TO_USDC,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .refresh_obligation(&mut test, &obligations[0])
+        .await
+        .unwrap();
+
+    let obligation_post = test.load_account::<Obligation>(obligations[0].pubkey).await;
+
+    // obligation 0 after borrowing 10 usd
+    // usdc.borrow_attribution = 80 / 100 * 30 = 24
+    assert_eq!(
+        obligation_post.account.deposits[0].attributed_borrow_value,
+        Decimal::from(24u64)
+    );
+
+    // wsol.borrow_attribution = 20 / 100 * 30 = 6
+    assert_eq!(
+        obligation_post.account.deposits[1].attributed_borrow_value,
+        Decimal::from(6u64)
+    );
+
+    let usdc_reserve_post = test.load_account::<Reserve>(reserves[0].pubkey).await;
+    assert_eq!(
+        usdc_reserve_post.account.attributed_borrow_value,
+        Decimal::from(120u64)
+    );
+
+    let wsol_reserve_post = test.load_account::<Reserve>(reserves[1].pubkey).await;
+    assert_eq!(
+        wsol_reserve_post.account.attributed_borrow_value,
+        Decimal::from(30u64)
+    );
+}

--- a/token-lending/program/tests/attributed_borrows.rs
+++ b/token-lending/program/tests/attributed_borrows.rs
@@ -1,8 +1,17 @@
 #![cfg(feature = "test-bpf")]
 
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+use solend_sdk::instruction::refresh_obligation;
+
 use crate::solend_program_test::custom_scenario;
+use crate::solend_program_test::SolendProgramTest;
 use crate::solend_program_test::User;
+use solana_sdk::pubkey::Pubkey;
 use solend_program::math::TryDiv;
+use solend_program::processor::process_instruction;
+use solend_sdk::state::ObligationCollateral;
+use solend_sdk::state::ObligationLiquidity;
+use solend_sdk::state::PROGRAM_VERSION;
 
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::transaction::TransactionError;
@@ -30,7 +39,7 @@ use solana_program_test::*;
 
 #[tokio::test]
 async fn test_refresh_obligation() {
-    let (mut test, lending_market, reserves, obligations, users, lending_market_owner) =
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
         custom_scenario(
             &[
                 ReserveArgs {
@@ -849,5 +858,117 @@ async fn test_liquidate() {
     assert_eq!(
         usdc_reserve_post.account.attributed_borrow_value,
         Decimal::zero()
+    );
+}
+
+#[tokio::test]
+async fn test_calculation_on_program_upgrade() {
+    let mut test = ProgramTest::new(
+        "solend_program",
+        solend_program::id(),
+        processor!(process_instruction),
+    );
+
+    let reserve_1 = Reserve {
+        version: PROGRAM_VERSION,
+        last_update: LastUpdate {
+            slot: 1,
+            stale: false,
+        },
+        attributed_borrow_value: Decimal::from(10u64),
+        liquidity: ReserveLiquidity {
+            market_price: Decimal::from(10u64),
+            mint_decimals: 0,
+            ..ReserveLiquidity::default()
+        },
+        ..Reserve::default()
+    };
+    let reserve_1_pubkey = Pubkey::new_unique();
+
+    test.add_packable_account(
+        reserve_1_pubkey,
+        u32::MAX as u64,
+        &reserve_1,
+        &solend_program::id(),
+    );
+
+    let reserve_2 = Reserve {
+        version: PROGRAM_VERSION,
+        last_update: LastUpdate {
+            slot: 1,
+            stale: false,
+        },
+        liquidity: ReserveLiquidity {
+            market_price: Decimal::from(10u64),
+            mint_decimals: 0,
+            ..ReserveLiquidity::default()
+        },
+        ..Reserve::default()
+    };
+    let reserve_2_pubkey = Pubkey::new_unique();
+    test.add_packable_account(
+        reserve_2_pubkey,
+        u32::MAX as u64,
+        &reserve_2,
+        &solend_program::id(),
+    );
+
+    let obligation_pubkey = Pubkey::new_unique();
+    let obligation = Obligation {
+        version: PROGRAM_VERSION,
+        deposits: vec![ObligationCollateral {
+            deposit_reserve: reserve_1_pubkey,
+            deposited_amount: 2u64,
+            market_value: Decimal::from(20u64),
+            attributed_borrow_value: Decimal::from(10u64),
+        }],
+        borrows: vec![ObligationLiquidity {
+            borrow_reserve: reserve_2_pubkey,
+            borrowed_amount_wads: Decimal::from(1u64),
+            ..ObligationLiquidity::default()
+        }],
+        updated_borrow_attribution_after_upgrade: false,
+        ..Obligation::default()
+    };
+
+    test.add_packable_account(
+        obligation_pubkey,
+        u32::MAX as u64,
+        &obligation,
+        &solend_program::id(),
+    );
+
+    let mut test = SolendProgramTest::start_with_test(test).await;
+
+    let ix = [refresh_obligation(
+        solend_program::id(),
+        obligation_pubkey,
+        vec![reserve_1_pubkey, reserve_2_pubkey],
+    )];
+
+    test.process_transaction(&ix, None).await.unwrap();
+
+    let reserve_1 = test.load_account::<Reserve>(reserve_1_pubkey).await;
+    assert_eq!(
+        reserve_1.account.attributed_borrow_value,
+        Decimal::from(20u64)
+    );
+
+    // run it again, this time make sure the borrow attribution value gets correctly subtracted
+    let ix = [
+        ComputeBudgetInstruction::set_compute_unit_price(1),
+        refresh_obligation(
+            solend_program::id(),
+            obligation_pubkey,
+            vec![reserve_1_pubkey, reserve_2_pubkey],
+        ),
+    ];
+
+    test.process_transaction(&ix, None).await.unwrap();
+
+    let reserve_1 = test.load_account::<Reserve>(reserve_1_pubkey).await;
+    assert_eq!(
+        reserve_1.account.attributed_borrow_value,
+        Decimal::from(20u64)
     );
 }

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -267,7 +267,7 @@ async fn test_success() {
                                                // refresh_obligation
             }],
             deposited_value: Decimal::from(100u64),
-            borrowed_value: Decimal::zero(),
+            borrowed_value: borrow_value,
             allowed_borrow_value: Decimal::from(50u64),
             unhealthy_borrow_value: Decimal::from(55u64),
             ..obligation.account

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -177,6 +177,11 @@ async fn test_success() {
     let lending_market_post = test
         .load_account::<LendingMarket>(lending_market.pubkey)
         .await;
+
+    let borrow_value = Decimal::from(10 * (4 * LAMPORTS_PER_SOL + 400))
+        .try_div(Decimal::from(1_000_000_000_u64))
+        .unwrap();
+
     assert_eq!(
         lending_market_post.account,
         LendingMarket {
@@ -194,6 +199,21 @@ async fn test_success() {
             },
             ..lending_market.account
         }
+    );
+
+    let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
+    assert_eq!(
+        usdc_reserve_post.account,
+        Reserve {
+            last_update: LastUpdate {
+                slot: 1000,
+                stale: false,
+            },
+            attributed_borrow_value: borrow_value,
+            ..usdc_reserve.account
+        },
+        "{:#?}",
+        usdc_reserve_post,
     );
 
     let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
@@ -232,6 +252,10 @@ async fn test_success() {
                 slot: 1000,
                 stale: true
             },
+            deposits: vec![ObligationCollateral {
+                attributed_borrow_value: borrow_value,
+                ..obligation.account.deposits[0]
+            }],
             borrows: vec![ObligationLiquidity {
                 borrow_reserve: wsol_reserve.pubkey,
                 borrowed_amount_wads: Decimal::from(4 * LAMPORTS_PER_SOL + 400),

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -268,6 +268,7 @@ async fn test_success() {
             }],
             deposited_value: Decimal::from(100u64),
             borrowed_value: borrow_value,
+            true_borrowed_value: borrow_value,
             allowed_borrow_value: Decimal::from(50u64),
             unhealthy_borrow_value: Decimal::from(55u64),
             ..obligation.account

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -268,7 +268,7 @@ async fn test_success() {
             }],
             deposited_value: Decimal::from(100u64),
             borrowed_value: borrow_value,
-            true_borrowed_value: borrow_value,
+            unweighted_borrowed_value: borrow_value,
             allowed_borrow_value: Decimal::from(50u64),
             unhealthy_borrow_value: Decimal::from(55u64),
             ..obligation.account

--- a/token-lending/program/tests/borrow_weight.rs
+++ b/token-lending/program/tests/borrow_weight.rs
@@ -176,6 +176,8 @@ async fn test_borrow() {
 
     test.advance_clock_by_slots(1).await;
 
+    let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
+
     // max withdraw
     {
         let balance_checker = BalanceChecker::start(&mut test, &[&user]).await;

--- a/token-lending/program/tests/deposit_obligation_collateral.rs
+++ b/token-lending/program/tests/deposit_obligation_collateral.rs
@@ -91,7 +91,8 @@ async fn test_success() {
             deposits: vec![ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: 1_000_000,
-                market_value: Decimal::zero() // this field only gets updated on a refresh
+                market_value: Decimal::zero(), // this field only gets updated on a refresh
+                attributed_borrow_value: Decimal::zero()
             }],
             ..obligation.account
         }

--- a/token-lending/program/tests/deposit_reserve_liquidity_and_obligation_collateral.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity_and_obligation_collateral.rs
@@ -130,7 +130,8 @@ async fn test_success() {
             deposits: [ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: 1_000_000,
-                market_value: Decimal::zero()
+                market_value: Decimal::zero(),
+                attributed_borrow_value: Decimal::zero()
             }]
             .to_vec(),
             ..obligation.account

--- a/token-lending/program/tests/forgive_debt.rs
+++ b/token-lending/program/tests/forgive_debt.rs
@@ -177,7 +177,7 @@ async fn test_forgive_debt_success_easy() {
             borrows: vec![],
             deposited_value: Decimal::zero(),
             borrowed_value: Decimal::from(8u64),
-            true_borrowed_value: Decimal::from(8u64),
+            unweighted_borrowed_value: Decimal::from(8u64),
             borrowed_value_upper_bound: Decimal::from(8u64),
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero(),

--- a/token-lending/program/tests/forgive_debt.rs
+++ b/token-lending/program/tests/forgive_debt.rs
@@ -177,6 +177,7 @@ async fn test_forgive_debt_success_easy() {
             borrows: vec![],
             deposited_value: Decimal::zero(),
             borrowed_value: Decimal::from(8u64),
+            true_borrowed_value: Decimal::from(8u64),
             borrowed_value_upper_bound: Decimal::from(8u64),
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero(),

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -55,6 +55,7 @@ pub fn test_reserve_config() -> ReserveConfig {
         reserve_type: ReserveType::Regular,
         scaled_price_offset_bps: 0,
         extra_oracle_pubkey: None,
+        attributed_borrow_limit: u64::MAX,
     }
 }
 

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -28,6 +28,38 @@ pub const QUOTE_CURRENCY: [u8; 32] =
 pub const LAMPORTS_TO_SOL: u64 = 1_000_000_000;
 pub const FRACTIONAL_TO_USDC: u64 = 1_000_000;
 
+pub fn reserve_config_no_fees() -> ReserveConfig {
+    ReserveConfig {
+        optimal_utilization_rate: 80,
+        max_utilization_rate: 80,
+        loan_to_value_ratio: 50,
+        liquidation_bonus: 0,
+        max_liquidation_bonus: 0,
+        liquidation_threshold: 55,
+        max_liquidation_threshold: 65,
+        min_borrow_rate: 0,
+        optimal_borrow_rate: 0,
+        max_borrow_rate: 0,
+        super_max_borrow_rate: 0,
+        fees: ReserveFees {
+            borrow_fee_wad: 0,
+            flash_loan_fee_wad: 0,
+            host_fee_percentage: 0,
+        },
+        deposit_limit: u64::MAX,
+        borrow_limit: u64::MAX,
+        fee_receiver: Keypair::new().pubkey(),
+        protocol_liquidation_fee: 0,
+        protocol_take_rate: 0,
+        added_borrow_weight_bps: 0,
+        reserve_type: ReserveType::Regular,
+        scaled_price_offset_bps: 0,
+        extra_oracle_pubkey: None,
+        attributed_borrow_limit_open: u64::MAX,
+        attributed_borrow_limit_close: u64::MAX,
+    }
+}
+
 pub fn test_reserve_config() -> ReserveConfig {
     ReserveConfig {
         optimal_utilization_rate: 80,
@@ -55,7 +87,8 @@ pub fn test_reserve_config() -> ReserveConfig {
         reserve_type: ReserveType::Regular,
         scaled_price_offset_bps: 0,
         extra_oracle_pubkey: None,
-        attributed_borrow_limit: u64::MAX,
+        attributed_borrow_limit_open: u64::MAX,
+        attributed_borrow_limit_close: u64::MAX,
     }
 }
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -680,6 +680,7 @@ impl User {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PriceArgs {
     pub price: i64,
     pub conf: u64,
@@ -994,7 +995,7 @@ impl Info<LendingMarket> {
             Err(e) => return Err(e),
         };
 
-        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(80_000)];
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_000_000)];
         instructions.push(refresh_reserve_instructions.last().unwrap().clone());
 
         test.process_transaction(&instructions, None).await
@@ -1016,7 +1017,7 @@ impl Info<LendingMarket> {
             .await;
         test.process_transaction(&refresh_ixs, None).await.unwrap();
 
-        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(80_000)];
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_000_000)];
         instructions.push(borrow_obligation_liquidity(
             solend_program::id(),
             liquidity_amount,
@@ -1685,6 +1686,7 @@ pub async fn scenario_1(
     )
 }
 
+#[derive(Debug, Clone)]
 pub struct ReserveArgs {
     pub mint: Pubkey,
     pub config: ReserveConfig,
@@ -1709,9 +1711,17 @@ pub async fn custom_scenario(
     User,
 ) {
     let mut test = SolendProgramTest::start_new().await;
-    let mints_and_liquidity_amounts = reserve_args
-        .iter()
-        .map(|reserve_arg| (&reserve_arg.mint, reserve_arg.liquidity_amount))
+    let mut mints_and_liquidity_amounts = HashMap::new();
+    for arg in reserve_args {
+        mints_and_liquidity_amounts
+            .entry(&arg.mint)
+            .and_modify(|e| *e += arg.liquidity_amount)
+            .or_insert(arg.liquidity_amount);
+    }
+
+    let mints_and_liquidity_amounts = mints_and_liquidity_amounts
+        .into_iter()
+        .map(|(mint, liquidity_amount)| (mint, liquidity_amount))
         .collect::<Vec<_>>();
 
     let lending_market_owner =

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1016,7 +1016,7 @@ impl Info<LendingMarket> {
             .await;
         test.process_transaction(&refresh_ixs, None).await.unwrap();
 
-        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(55_000)];
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(60_000)];
         instructions.push(borrow_obligation_liquidity(
             solend_program::id(),
             liquidity_amount,
@@ -1837,7 +1837,10 @@ pub async fn custom_scenario(
 
     // load accounts into reserve
     for reserve in reserves.iter_mut() {
-        lending_market.refresh_reserve(&mut test, reserve).await.unwrap();
+        lending_market
+            .refresh_reserve(&mut test, reserve)
+            .await
+            .unwrap();
 
         *reserve = test.load_account(reserve.pubkey).await;
     }

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1837,6 +1837,8 @@ pub async fn custom_scenario(
 
     // load accounts into reserve
     for reserve in reserves.iter_mut() {
+        lending_market.refresh_reserve(&mut test, reserve).await.unwrap();
+
         *reserve = test.load_account(reserve.pubkey).await;
     }
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1016,7 +1016,7 @@ impl Info<LendingMarket> {
             .await;
         test.process_transaction(&refresh_ixs, None).await.unwrap();
 
-        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(60_000)];
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(80_000)];
         instructions.push(borrow_obligation_liquidity(
             solend_program::id(),
             liquidity_amount,
@@ -1028,6 +1028,7 @@ impl Info<LendingMarket> {
             obligation.pubkey,
             self.pubkey,
             user.keypair.pubkey(),
+            obligation.account.deposits.iter().map(|d| d.deposit_reserve).collect(),
             host_fee_receiver_pubkey,
         ));
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1651,6 +1651,11 @@ pub async fn scenario_1(
         .await
         .unwrap();
 
+    lending_market
+        .refresh_reserve(&mut test, &usdc_reserve)
+        .await
+        .unwrap();
+
     // populate deposit value correctly.
     let obligation = test.load_account::<Obligation>(obligation.pubkey).await;
     lending_market

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1028,7 +1028,12 @@ impl Info<LendingMarket> {
             obligation.pubkey,
             self.pubkey,
             user.keypair.pubkey(),
-            obligation.account.deposits.iter().map(|d| d.deposit_reserve).collect(),
+            obligation
+                .account
+                .deposits
+                .iter()
+                .map(|d| d.deposit_reserve)
+                .collect(),
             host_fee_receiver_pubkey,
         ));
 

--- a/token-lending/program/tests/helpers/solend_program_test.rs
+++ b/token-lending/program/tests/helpers/solend_program_test.rs
@@ -1188,7 +1188,7 @@ impl Info<LendingMarket> {
 
         test.process_transaction(
             &[
-                ComputeBudgetInstruction::set_compute_unit_limit(70_000),
+                ComputeBudgetInstruction::set_compute_unit_limit(100_000),
                 withdraw_obligation_collateral_and_redeem_reserve_collateral(
                     solend_program::id(),
                     collateral_amount,
@@ -1204,6 +1204,12 @@ impl Info<LendingMarket> {
                     withdraw_reserve.account.liquidity.supply_pubkey,
                     user.keypair.pubkey(),
                     user.keypair.pubkey(),
+                    obligation
+                        .account
+                        .deposits
+                        .iter()
+                        .map(|d| d.deposit_reserve)
+                        .collect(),
                 ),
             ],
             Some(&[&user.keypair]),
@@ -1226,7 +1232,7 @@ impl Info<LendingMarket> {
 
         test.process_transaction(
             &[
-                ComputeBudgetInstruction::set_compute_unit_limit(40_000),
+                ComputeBudgetInstruction::set_compute_unit_limit(100_000),
                 withdraw_obligation_collateral(
                     solend_program::id(),
                     collateral_amount,
@@ -1237,6 +1243,12 @@ impl Info<LendingMarket> {
                     obligation.pubkey,
                     self.pubkey,
                     user.keypair.pubkey(),
+                    obligation
+                        .account
+                        .deposits
+                        .iter()
+                        .map(|d| d.deposit_reserve)
+                        .collect(),
                 ),
             ],
             Some(&[&user.keypair]),

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -45,6 +45,7 @@ async fn test_success() {
             borrows: Vec::new(),
             deposited_value: Decimal::zero(),
             borrowed_value: Decimal::zero(),
+            true_borrowed_value: Decimal::zero(),
             borrowed_value_upper_bound: Decimal::zero(),
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero(),

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -45,7 +45,7 @@ async fn test_success() {
             borrows: Vec::new(),
             deposited_value: Decimal::zero(),
             borrowed_value: Decimal::zero(),
-            true_borrowed_value: Decimal::zero(),
+            unweighted_borrowed_value: Decimal::zero(),
             borrowed_value_upper_bound: Decimal::zero(),
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero(),

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -51,7 +51,7 @@ async fn test_success() {
             unhealthy_borrow_value: Decimal::zero(),
             super_unhealthy_borrow_value: Decimal::zero(),
             borrowing_isolated_asset: false,
-            updated_borrow_attribution_after_upgrade: false
+            closeable: false,
         }
     );
 }

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -50,7 +50,8 @@ async fn test_success() {
             allowed_borrow_value: Decimal::zero(),
             unhealthy_borrow_value: Decimal::zero(),
             super_unhealthy_borrow_value: Decimal::zero(),
-            borrowing_isolated_asset: false
+            borrowing_isolated_asset: false,
+            updated_borrow_attribution_after_upgrade: false
         }
     );
 }

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -180,7 +180,8 @@ async fn test_success() {
                 supply_pubkey: reserve_collateral_supply_pubkey,
             },
             config: reserve_config,
-            rate_limiter: RateLimiter::new(RateLimiterConfig::default(), 1001)
+            rate_limiter: RateLimiter::new(RateLimiterConfig::default(), 1001),
+            attributed_borrow_value: Decimal::zero(),
         }
     );
 }

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -124,7 +124,7 @@ async fn test_refresh_obligation() {
                 market_value: Decimal::from(10u64),
             }],
             borrowed_value: Decimal::from(10u64),
-            true_borrowed_value: Decimal::from(10u64),
+            unweighted_borrowed_value: Decimal::from(10u64),
             borrowed_value_upper_bound: Decimal::from(10u64),
             borrowing_isolated_asset: true,
             ..obligations[0].account.clone()

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::solend_program_test::custom_scenario;
+use solend_program::state::ObligationCollateral;
 
 use crate::solend_program_test::ObligationArgs;
 use crate::solend_program_test::PriceArgs;
@@ -112,6 +113,10 @@ async fn test_refresh_obligation() {
                 slot: 1001,
                 stale: false
             },
+            deposits: vec![ObligationCollateral {
+                attributed_borrow_value: Decimal::from(10u64),
+                ..obligations[0].account.deposits[0]
+            }],
             borrows: vec![ObligationLiquidity {
                 borrow_reserve: wsol_reserve.pubkey,
                 cumulative_borrow_rate_wads: Decimal::one(),

--- a/token-lending/program/tests/isolated_tier_assets.rs
+++ b/token-lending/program/tests/isolated_tier_assets.rs
@@ -124,6 +124,7 @@ async fn test_refresh_obligation() {
                 market_value: Decimal::from(10u64),
             }],
             borrowed_value: Decimal::from(10u64),
+            true_borrowed_value: Decimal::from(10u64),
             borrowed_value_upper_bound: Decimal::from(10u64),
             borrowing_isolated_asset: true,
             ..obligations[0].account.clone()

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -214,7 +214,9 @@ async fn test_success_new() {
             deposits: [ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: (100_000 - expected_usdc_withdrawn) * FRACTIONAL_TO_USDC,
-                market_value: Decimal::from(100_000u64) // old value
+                market_value: Decimal::from(100_000u64), // old value
+                attributed_borrow_value: obligation_post.account.deposits[0]
+                    .attributed_borrow_value, // don't care about verifying this here
             }]
             .to_vec(),
             borrows: [ObligationLiquidity {

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -231,7 +231,7 @@ async fn test_success_new() {
             .to_vec(),
             deposited_value: Decimal::from(100_000u64),
             borrowed_value: Decimal::from(55_000u64),
-            true_borrowed_value: Decimal::from(55_000u64),
+            unweighted_borrowed_value: Decimal::from(55_000u64),
             borrowed_value_upper_bound: Decimal::from(55_000u64),
             allowed_borrow_value: Decimal::from(50_000u64),
             unhealthy_borrow_value: Decimal::from(55_000u64),

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -178,6 +178,7 @@ async fn test_success_new() {
                     - expected_usdc_withdrawn * FRACTIONAL_TO_USDC,
                 ..usdc_reserve.account.collateral
             },
+            attributed_borrow_value: Decimal::from(55000u64),
             ..usdc_reserve.account
         }
     );

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -231,6 +231,7 @@ async fn test_success_new() {
             .to_vec(),
             deposited_value: Decimal::from(100_000u64),
             borrowed_value: Decimal::from(55_000u64),
+            true_borrowed_value: Decimal::from(55_000u64),
             borrowed_value_upper_bound: Decimal::from(55_000u64),
             allowed_borrow_value: Decimal::from(50_000u64),
             unhealthy_borrow_value: Decimal::from(55_000u64),

--- a/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
+++ b/token-lending/program/tests/liquidate_obligation_and_redeem_collateral.rs
@@ -15,6 +15,7 @@ use solend_program::state::ObligationCollateral;
 use solend_program::state::ObligationLiquidity;
 use solend_program::state::ReserveConfig;
 use solend_program::state::ReserveFees;
+use solend_sdk::state::Bonus;
 use solend_sdk::NULL_PUBKEY;
 mod helpers;
 
@@ -458,7 +459,12 @@ async fn test_success_insufficient_liquidity() {
         .account
         .calculate_protocol_liquidation_fee(
             available_amount * FRACTIONAL_TO_USDC,
-            Decimal::from_percent(105),
+            &Bonus {
+                total_bonus: Decimal::from_percent(bonus as u8),
+                protocol_liquidation_fee: Decimal::from_deca_bps(
+                    usdc_reserve.account.config.protocol_liquidation_fee,
+                ),
+            },
         )
         .unwrap();
 
@@ -659,4 +665,158 @@ async fn test_liquidity_ordering() {
         )
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_liquidate_closeable_obligation() {
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: ReserveConfig {
+                        liquidation_bonus: 5,
+                        max_liquidation_bonus: 10,
+                        protocol_liquidation_fee: 1,
+                        ..reserve_config_no_fees()
+                    },
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: reserve_config_no_fees(),
+                    liquidity_amount: LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 20 * FRACTIONAL_TO_USDC)],
+                borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
+            }],
+        )
+        .await;
+
+    let usdc_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == usdc_mint::id())
+        .unwrap();
+    let wsol_reserve = reserves
+        .iter()
+        .find(|r| r.account.liquidity.mint_pubkey == wsol_mint::id())
+        .unwrap();
+
+    let liquidator = User::new_with_balances(
+        &mut test,
+        &[
+            (&wsol_mint::id(), 100 * LAMPORTS_TO_SOL),
+            (&usdc_reserve.account.collateral.mint_pubkey, 0),
+            (&usdc_mint::id(), 0),
+        ],
+    )
+    .await;
+
+    let balance_checker =
+        BalanceChecker::start(&mut test, &[usdc_reserve, &liquidator, wsol_reserve]).await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            usdc_reserve,
+            ReserveConfig {
+                attributed_borrow_limit_open: 1,
+                attributed_borrow_limit_close: 1,
+                ..usdc_reserve.account.config
+            },
+            usdc_reserve.account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    lending_market
+        .set_obligation_closeability_status(
+            &mut test,
+            &obligations[0],
+            usdc_reserve,
+            &lending_market_owner,
+            true,
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .liquidate_obligation_and_redeem_reserve_collateral(
+            &mut test,
+            wsol_reserve,
+            usdc_reserve,
+            &obligations[0],
+            &liquidator,
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+    let (balance_changes, mint_supply_changes) =
+        balance_checker.find_balance_changes(&mut test).await;
+
+    let expected_balance_changes = HashSet::from([
+        // liquidator
+        TokenBalanceChange {
+            token_account: liquidator.get_account(&usdc_mint::id()).unwrap(),
+            mint: usdc_mint::id(),
+            diff: (2 * FRACTIONAL_TO_USDC - 1) as i128,
+        },
+        TokenBalanceChange {
+            token_account: liquidator.get_account(&wsol_mint::id()).unwrap(),
+            mint: wsol_mint::id(),
+            diff: -((LAMPORTS_PER_SOL / 5) as i128),
+        },
+        // usdc reserve
+        TokenBalanceChange {
+            token_account: usdc_reserve.account.collateral.supply_pubkey,
+            mint: usdc_reserve.account.collateral.mint_pubkey,
+            diff: -((2 * FRACTIONAL_TO_USDC) as i128),
+        },
+        TokenBalanceChange {
+            token_account: usdc_reserve.account.liquidity.supply_pubkey,
+            mint: usdc_mint::id(),
+            diff: -((2 * FRACTIONAL_TO_USDC) as i128),
+        },
+        TokenBalanceChange {
+            token_account: usdc_reserve.account.config.fee_receiver,
+            mint: usdc_mint::id(),
+            diff: 1,
+        },
+        // wsol reserve
+        TokenBalanceChange {
+            token_account: wsol_reserve.account.liquidity.supply_pubkey,
+            mint: wsol_mint::id(),
+            diff: (LAMPORTS_TO_SOL / 5) as i128,
+        },
+    ]);
+    assert_eq!(balance_changes, expected_balance_changes);
+
+    assert_eq!(
+        mint_supply_changes,
+        HashSet::from([MintSupplyChange {
+            mint: usdc_reserve.account.collateral.mint_pubkey,
+            diff: -((2 * FRACTIONAL_TO_USDC) as i128)
+        }])
+    );
 }

--- a/token-lending/program/tests/mark_obligation_as_closeable.rs
+++ b/token-lending/program/tests/mark_obligation_as_closeable.rs
@@ -1,0 +1,270 @@
+#![cfg(feature = "test-bpf")]
+
+use crate::solend_program_test::custom_scenario;
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+use crate::solend_program_test::User;
+
+use solana_sdk::signer::keypair::Keypair;
+use solana_sdk::signer::Signer;
+
+use crate::solend_program_test::ObligationArgs;
+use crate::solend_program_test::PriceArgs;
+use crate::solend_program_test::ReserveArgs;
+
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::transaction::TransactionError;
+use solend_program::error::LendingError;
+
+use solend_program::state::ReserveConfig;
+
+use solend_sdk::{instruction::LendingInstruction, solend_mainnet, state::*};
+mod helpers;
+
+use helpers::*;
+use solana_program_test::*;
+
+#[tokio::test]
+async fn test_mark_obligation_as_closeable_success() {
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: reserve_config_no_fees(),
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: reserve_config_no_fees(),
+                    liquidity_amount: LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 20 * FRACTIONAL_TO_USDC)],
+                borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
+            }],
+        )
+        .await;
+
+    let risk_authority = User::new_with_keypair(Keypair::new());
+    lending_market
+        .set_lending_market_owner_and_config(
+            &mut test,
+            &lending_market_owner,
+            &lending_market_owner.keypair.pubkey(),
+            lending_market.account.rate_limiter.config,
+            lending_market.account.whitelisted_liquidator,
+            risk_authority.keypair.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    test.advance_clock_by_slots(1).await;
+
+    let err = lending_market
+        .set_obligation_closeability_status(
+            &mut test,
+            &obligations[0],
+            &reserves[0],
+            &risk_authority,
+            true,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::BorrowAttributionLimitNotExceeded as u32)
+        )
+    );
+
+    test.advance_clock_by_slots(1).await;
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &reserves[0],
+            ReserveConfig {
+                attributed_borrow_limit_open: 1,
+                attributed_borrow_limit_close: 1,
+                ..reserves[0].account.config
+            },
+            reserves[0].account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    lending_market
+        .set_obligation_closeability_status(
+            &mut test,
+            &obligations[0],
+            &reserves[0],
+            &risk_authority,
+            true,
+        )
+        .await
+        .unwrap();
+
+    let obligation_post = test.load_account::<Obligation>(obligations[0].pubkey).await;
+    assert_eq!(
+        obligation_post.account,
+        Obligation {
+            last_update: LastUpdate {
+                slot: 1002,
+                stale: false
+            },
+            closeable: true,
+            ..obligations[0].account.clone()
+        }
+    );
+}
+
+#[tokio::test]
+async fn invalid_signer() {
+    let (mut test, lending_market, reserves, obligations, _users, lending_market_owner) =
+        custom_scenario(
+            &[
+                ReserveArgs {
+                    mint: usdc_mint::id(),
+                    config: reserve_config_no_fees(),
+                    liquidity_amount: 100_000 * FRACTIONAL_TO_USDC,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: -1,
+                        ema_price: 10,
+                        ema_conf: 1,
+                    },
+                },
+                ReserveArgs {
+                    mint: wsol_mint::id(),
+                    config: reserve_config_no_fees(),
+                    liquidity_amount: LAMPORTS_PER_SOL,
+                    price: PriceArgs {
+                        price: 10,
+                        conf: 0,
+                        expo: 0,
+                        ema_price: 10,
+                        ema_conf: 0,
+                    },
+                },
+            ],
+            &[ObligationArgs {
+                deposits: vec![(usdc_mint::id(), 20 * FRACTIONAL_TO_USDC)],
+                borrows: vec![(wsol_mint::id(), LAMPORTS_PER_SOL)],
+            }],
+        )
+        .await;
+
+    let risk_authority = User::new_with_keypair(Keypair::new());
+    lending_market
+        .set_lending_market_owner_and_config(
+            &mut test,
+            &lending_market_owner,
+            &lending_market_owner.keypair.pubkey(),
+            lending_market.account.rate_limiter.config,
+            lending_market.account.whitelisted_liquidator,
+            risk_authority.keypair.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    lending_market
+        .update_reserve_config(
+            &mut test,
+            &lending_market_owner,
+            &reserves[0],
+            ReserveConfig {
+                attributed_borrow_limit_open: 1,
+                attributed_borrow_limit_close: 1,
+                ..reserves[0].account.config
+            },
+            reserves[0].account.rate_limiter.config,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let rando = User::new_with_keypair(Keypair::new());
+    let err = lending_market
+        .set_obligation_closeability_status(&mut test, &obligations[0], &reserves[0], &rando, true)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
+    );
+
+    let err = test
+        .process_transaction(
+            &[malicious_set_obligation_closeability_status(
+                solend_mainnet::id(),
+                obligations[0].pubkey,
+                reserves[0].pubkey,
+                lending_market.pubkey,
+                risk_authority.keypair.pubkey(),
+                true,
+            )],
+            None,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidSigner as u32)
+        )
+    );
+}
+
+pub fn malicious_set_obligation_closeability_status(
+    program_id: Pubkey,
+    obligation_pubkey: Pubkey,
+    reserve_pubkey: Pubkey,
+    lending_market_pubkey: Pubkey,
+    risk_authority: Pubkey,
+    closeable: bool,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(obligation_pubkey, false),
+            AccountMeta::new_readonly(lending_market_pubkey, false),
+            AccountMeta::new_readonly(reserve_pubkey, false),
+            AccountMeta::new_readonly(risk_authority, false),
+        ],
+        data: LendingInstruction::SetObligationCloseabilityStatus { closeable }.pack(),
+    }
+}

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -258,7 +258,8 @@ async fn test_success() {
             deposits: [ObligationCollateral {
                 attributed_borrow_value: new_borrow_value,
                 ..obligation.account.deposits[0]
-            }].to_vec(),
+            }]
+            .to_vec(),
             borrows: [ObligationLiquidity {
                 borrow_reserve: wsol_reserve.pubkey,
                 cumulative_borrow_rate_wads: new_cumulative_borrow_rate,

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -274,6 +274,12 @@ async fn test_success() {
                 .try_div(Decimal::from(LAMPORTS_PER_SOL))
                 .unwrap(),
 
+            true_borrowed_value: new_borrowed_amount_wads
+                .try_mul(Decimal::from(10u64))
+                .unwrap()
+                .try_div(Decimal::from(LAMPORTS_PER_SOL))
+                .unwrap(),
+
             // uses max(10, 11) = 11 for sol price
             borrowed_value_upper_bound: new_borrowed_amount_wads
                 .try_mul(Decimal::from(11u64))

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -274,7 +274,7 @@ async fn test_success() {
                 .try_div(Decimal::from(LAMPORTS_PER_SOL))
                 .unwrap(),
 
-            true_borrowed_value: new_borrowed_amount_wads
+            unweighted_borrowed_value: new_borrowed_amount_wads
                 .try_mul(Decimal::from(10u64))
                 .unwrap()
                 .try_div(Decimal::from(LAMPORTS_PER_SOL))

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -192,6 +192,23 @@ async fn test_success() {
         .await;
     assert_eq!(lending_market_post, lending_market);
 
+    // 1 + 0.3/SLOTS_PER_YEAR
+    let new_cumulative_borrow_rate = Decimal::one()
+        .try_add(
+            Decimal::from_percent(wsol_reserve.account.config.max_borrow_rate)
+                .try_div(Decimal::from(SLOTS_PER_YEAR))
+                .unwrap(),
+        )
+        .unwrap();
+    let new_borrowed_amount_wads = new_cumulative_borrow_rate
+        .try_mul(Decimal::from(6 * LAMPORTS_PER_SOL))
+        .unwrap();
+    let new_borrow_value = new_borrowed_amount_wads
+        .try_mul(Decimal::from(10u64))
+        .unwrap()
+        .try_div(Decimal::from(LAMPORTS_PER_SOL))
+        .unwrap();
+
     let usdc_reserve_post = test.load_account::<Reserve>(usdc_reserve.pubkey).await;
     assert_eq!(
         usdc_reserve_post.account,
@@ -204,23 +221,12 @@ async fn test_success() {
                 smoothed_market_price: Decimal::from_percent(90),
                 ..usdc_reserve.account.liquidity
             },
+            attributed_borrow_value: new_borrow_value,
             ..usdc_reserve.account
         }
     );
 
     let wsol_reserve_post = test.load_account::<Reserve>(wsol_reserve.pubkey).await;
-
-    // 1 + 0.3/SLOTS_PER_YEAR
-    let new_cumulative_borrow_rate = Decimal::one()
-        .try_add(
-            Decimal::from_percent(wsol_reserve.account.config.max_borrow_rate)
-                .try_div(Decimal::from(SLOTS_PER_YEAR))
-                .unwrap(),
-        )
-        .unwrap();
-    let new_borrowed_amount_wads = new_cumulative_borrow_rate
-        .try_mul(Decimal::from(6 * LAMPORTS_PER_SOL))
-        .unwrap();
 
     assert_eq!(
         wsol_reserve_post.account,
@@ -241,11 +247,6 @@ async fn test_success() {
     );
 
     let obligation_post = test.load_account::<Obligation>(obligation.pubkey).await;
-    let new_borrow_value = new_borrowed_amount_wads
-        .try_mul(Decimal::from(10u64))
-        .unwrap()
-        .try_div(Decimal::from(LAMPORTS_PER_SOL))
-        .unwrap();
 
     assert_eq!(
         obligation_post.account,
@@ -254,6 +255,10 @@ async fn test_success() {
                 slot: 1001,
                 stale: false
             },
+            deposits: [ObligationCollateral {
+                attributed_borrow_value: new_borrow_value,
+                ..obligation.account.deposits[0]
+            }].to_vec(),
             borrows: [ObligationLiquidity {
                 borrow_reserve: wsol_reserve.pubkey,
                 cumulative_borrow_rate_wads: new_cumulative_borrow_rate,

--- a/token-lending/program/tests/two_prices.rs
+++ b/token-lending/program/tests/two_prices.rs
@@ -478,7 +478,7 @@ async fn test_liquidation_doesnt_use_smoothed_price() {
         TokenBalanceChange {
             token_account: liquidator.get_account(&usdc_mint::id()).unwrap(),
             mint: usdc_mint::id(),
-            diff: (20 * FRACTIONAL_TO_USDC * 105 / 100) as i128 - 1,
+            diff: (20 * FRACTIONAL_TO_USDC * 105 / 100 - 1) as i128,
         },
         TokenBalanceChange {
             token_account: liquidator.get_account(&wsol_mint::id()).unwrap(),

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "test-bpf")]
 
-use solend_program::math::TrySub;
 mod helpers;
 
-use solend_sdk::math::Decimal;
 use crate::solend_program_test::scenario_1;
 use helpers::solend_program_test::{BalanceChecker, TokenBalanceChange};
 use helpers::*;
+use solend_sdk::math::Decimal;
 
 use solana_program_test::*;
 

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
+use solend_program::math::TrySub;
 mod helpers;
 
+use solend_sdk::math::Decimal;
 use crate::solend_program_test::scenario_1;
 use helpers::solend_program_test::{BalanceChecker, TokenBalanceChange};
 use helpers::*;
@@ -58,9 +60,11 @@ async fn test_success_withdraw_fixed_amount() {
             deposits: [ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: 100_000_000_000 - 1_000_000,
+                market_value: Decimal::from(99_999u64),
                 ..obligation.account.deposits[0]
             }]
             .to_vec(),
+            deposited_value: Decimal::from(99_999u64),
             ..obligation.account
         }
     );
@@ -121,9 +125,11 @@ async fn test_success_withdraw_max() {
             deposits: [ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: expected_remaining_collateral,
+                market_value: Decimal::from(200u64),
                 ..obligation.account.deposits[0]
             }]
             .to_vec(),
+            deposited_value: Decimal::from(200u64),
             ..obligation.account
         }
     );

--- a/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral_and_redeem_reserve_collateral.rs
@@ -141,9 +141,11 @@ async fn test_success() {
             deposits: [ObligationCollateral {
                 deposit_reserve: usdc_reserve.pubkey,
                 deposited_amount: 200 * FRACTIONAL_TO_USDC,
+                market_value: Decimal::from(200u64),
                 ..obligation.account.deposits[0]
             }]
             .to_vec(),
+            deposited_value: Decimal::from(200u64),
             ..obligation.account
         }
     );

--- a/token-lending/sdk/src/error.rs
+++ b/token-lending/sdk/src/error.rs
@@ -203,6 +203,9 @@ pub enum LendingError {
     /// Isolated Tier Asset Violation
     #[error("Isolated Tier Asset Violation")]
     IsolatedTierAssetViolation,
+    /// Borrow Attribution Limit Exceeded
+    #[error("Borrow Attribution Limit Exceeded")]
+    BorrowAttributionLimitExceeded,
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/sdk/src/error.rs
+++ b/token-lending/sdk/src/error.rs
@@ -206,6 +206,9 @@ pub enum LendingError {
     /// Borrow Attribution Limit Exceeded
     #[error("Borrow Attribution Limit Exceeded")]
     BorrowAttributionLimitExceeded,
+    /// Borrow Attribution Limit Not Exceeded
+    #[error("Borrow Attribution Limit Not Exceeded")]
+    BorrowAttributionLimitNotExceeded,
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1440,6 +1440,7 @@ pub fn borrow_obligation_liquidity(
     obligation_pubkey: Pubkey,
     lending_market_pubkey: Pubkey,
     obligation_owner_pubkey: Pubkey,
+    collateral_reserves: Vec<Pubkey>,
     host_fee_receiver_pubkey: Option<Pubkey>,
 ) -> Instruction {
     let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
@@ -1457,6 +1458,10 @@ pub fn borrow_obligation_liquidity(
         AccountMeta::new_readonly(obligation_owner_pubkey, true),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];
+    for collateral_reserve in collateral_reserves {
+        accounts.push(AccountMeta::new(collateral_reserve, false));
+    }
+
     if let Some(host_fee_receiver_pubkey) = host_fee_receiver_pubkey {
         accounts.push(AccountMeta::new(host_fee_receiver_pubkey, false));
     }

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1417,7 +1417,7 @@ pub fn withdraw_obligation_collateral(
     obligation_pubkey: Pubkey,
     lending_market_pubkey: Pubkey,
     obligation_owner_pubkey: Pubkey,
-    collateral_reserves: Vec<Pubkey>
+    collateral_reserves: Vec<Pubkey>,
 ) -> Instruction {
     let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
         &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -1368,27 +1368,37 @@ pub fn withdraw_obligation_collateral_and_redeem_reserve_collateral(
     reserve_liquidity_supply_pubkey: Pubkey,
     obligation_owner_pubkey: Pubkey,
     user_transfer_authority_pubkey: Pubkey,
+    collateral_reserves: Vec<Pubkey>,
 ) -> Instruction {
     let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
         &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
         &program_id,
     );
+
+    let mut accounts = vec![
+        AccountMeta::new(source_collateral_pubkey, false),
+        AccountMeta::new(destination_collateral_pubkey, false),
+        AccountMeta::new(withdraw_reserve_pubkey, false),
+        AccountMeta::new(obligation_pubkey, false),
+        AccountMeta::new(lending_market_pubkey, false),
+        AccountMeta::new_readonly(lending_market_authority_pubkey, false),
+        AccountMeta::new(destination_liquidity_pubkey, false),
+        AccountMeta::new(reserve_collateral_mint_pubkey, false),
+        AccountMeta::new(reserve_liquidity_supply_pubkey, false),
+        AccountMeta::new_readonly(obligation_owner_pubkey, true),
+        AccountMeta::new_readonly(user_transfer_authority_pubkey, true),
+        AccountMeta::new_readonly(spl_token::id(), false),
+    ];
+
+    accounts.extend(
+        collateral_reserves
+            .into_iter()
+            .map(|pubkey| AccountMeta::new(pubkey, false)),
+    );
+
     Instruction {
         program_id,
-        accounts: vec![
-            AccountMeta::new(source_collateral_pubkey, false),
-            AccountMeta::new(destination_collateral_pubkey, false),
-            AccountMeta::new(withdraw_reserve_pubkey, false),
-            AccountMeta::new(obligation_pubkey, false),
-            AccountMeta::new(lending_market_pubkey, false),
-            AccountMeta::new_readonly(lending_market_authority_pubkey, false),
-            AccountMeta::new(destination_liquidity_pubkey, false),
-            AccountMeta::new(reserve_collateral_mint_pubkey, false),
-            AccountMeta::new(reserve_liquidity_supply_pubkey, false),
-            AccountMeta::new_readonly(obligation_owner_pubkey, true),
-            AccountMeta::new_readonly(user_transfer_authority_pubkey, true),
-            AccountMeta::new_readonly(spl_token::id(), false),
-        ],
+        accounts,
         data: LendingInstruction::WithdrawObligationCollateralAndRedeemReserveCollateral {
             collateral_amount,
         }
@@ -1407,23 +1417,33 @@ pub fn withdraw_obligation_collateral(
     obligation_pubkey: Pubkey,
     lending_market_pubkey: Pubkey,
     obligation_owner_pubkey: Pubkey,
+    collateral_reserves: Vec<Pubkey>
 ) -> Instruction {
     let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
         &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
         &program_id,
     );
+
+    let mut accounts = vec![
+        AccountMeta::new(source_collateral_pubkey, false),
+        AccountMeta::new(destination_collateral_pubkey, false),
+        AccountMeta::new_readonly(withdraw_reserve_pubkey, false),
+        AccountMeta::new(obligation_pubkey, false),
+        AccountMeta::new_readonly(lending_market_pubkey, false),
+        AccountMeta::new_readonly(lending_market_authority_pubkey, false),
+        AccountMeta::new_readonly(obligation_owner_pubkey, true),
+        AccountMeta::new_readonly(spl_token::id(), false),
+    ];
+
+    accounts.extend(
+        collateral_reserves
+            .into_iter()
+            .map(|pubkey| AccountMeta::new(pubkey, false)),
+    );
+
     Instruction {
         program_id,
-        accounts: vec![
-            AccountMeta::new(source_collateral_pubkey, false),
-            AccountMeta::new(destination_collateral_pubkey, false),
-            AccountMeta::new_readonly(withdraw_reserve_pubkey, false),
-            AccountMeta::new(obligation_pubkey, false),
-            AccountMeta::new_readonly(lending_market_pubkey, false),
-            AccountMeta::new_readonly(lending_market_authority_pubkey, false),
-            AccountMeta::new_readonly(obligation_owner_pubkey, true),
-            AccountMeta::new_readonly(spl_token::id(), false),
-        ],
+        accounts,
         data: LendingInstruction::WithdrawObligationCollateral { collateral_amount }.pack(),
     }
 }

--- a/token-lending/sdk/src/math/common.rs
+++ b/token-lending/sdk/src/math/common.rs
@@ -19,6 +19,12 @@ pub trait TrySub: Sized {
     fn try_sub(self, rhs: Self) -> Result<Self, ProgramError>;
 }
 
+/// Subtract and set to zero on underflow
+pub trait SaturatingSub: Sized {
+    /// Subtract
+    fn saturating_sub(self, rhs: Self) -> Self;
+}
+
 /// Try to subtract, return an error on overflow
 pub trait TryAdd: Sized {
     /// Add

--- a/token-lending/sdk/src/math/decimal.rs
+++ b/token-lending/sdk/src/math/decimal.rs
@@ -165,6 +165,12 @@ impl TrySub for Decimal {
     }
 }
 
+impl SaturatingSub for Decimal {
+    fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
 impl TryDiv<u64> for Decimal {
     fn try_div(self, rhs: u64) -> Result<Self, ProgramError> {
         Ok(Self(

--- a/token-lending/sdk/src/math/decimal.rs
+++ b/token-lending/sdk/src/math/decimal.rs
@@ -313,4 +313,16 @@ mod test {
             "0.000000000000000001"
         );
     }
+
+    #[test]
+    fn test_saturating_sub() {
+        assert_eq!(
+            Decimal::from(1u64).saturating_sub(Decimal::from(2u64)),
+            Decimal::zero()
+        );
+        assert_eq!(
+            Decimal::from(2u64).saturating_sub(Decimal::from(1u64)),
+            Decimal::one()
+        );
+    }
 }

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -61,6 +61,8 @@ pub struct Obligation {
     pub super_unhealthy_borrow_value: Decimal,
     /// True if the obligation is currently borrowing an isolated tier asset
     pub borrowing_isolated_asset: bool,
+    /// Updated borrow attribution after upgrade. initially false when upgrading to v2.0.3
+    pub updated_borrow_attribution_after_upgrade: bool,
 }
 
 impl Obligation {
@@ -433,7 +435,8 @@ impl Pack for Obligation {
             borrowed_value_upper_bound,
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
-            true_borrowed_value,
+            unweighted_borrowed_value,
+            updated_borrow_attribution_after_upgrade,
             _padding,
             deposits_len,
             borrows_len,
@@ -453,7 +456,8 @@ impl Pack for Obligation {
             1,
             16,
             16,
-            15,
+            1,
+            14,
             1,
             1,
             OBLIGATION_COLLATERAL_LEN + (OBLIGATION_LIQUIDITY_LEN * (MAX_OBLIGATION_RESERVES - 1))
@@ -475,7 +479,11 @@ impl Pack for Obligation {
             self.super_unhealthy_borrow_value,
             super_unhealthy_borrow_value,
         );
-        pack_decimal(self.unweighted_borrowed_value, true_borrowed_value);
+        pack_decimal(self.unweighted_borrowed_value, unweighted_borrowed_value);
+        pack_bool(
+            self.updated_borrow_attribution_after_upgrade,
+            updated_borrow_attribution_after_upgrade,
+        );
 
         *deposits_len = u8::try_from(self.deposits.len()).unwrap().to_le_bytes();
         *borrows_len = u8::try_from(self.borrows.len()).unwrap().to_le_bytes();
@@ -539,7 +547,8 @@ impl Pack for Obligation {
             borrowed_value_upper_bound,
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
-            true_borrowed_value,
+            unweighted_borrowed_value,
+            updated_borrow_attribution_after_upgrade,
             _padding,
             deposits_len,
             borrows_len,
@@ -559,7 +568,8 @@ impl Pack for Obligation {
             1,
             16,
             16,
-            15,
+            1,
+            14,
             1,
             1,
             OBLIGATION_COLLATERAL_LEN + (OBLIGATION_LIQUIDITY_LEN * (MAX_OBLIGATION_RESERVES - 1))
@@ -626,12 +636,15 @@ impl Pack for Obligation {
             borrows,
             deposited_value: unpack_decimal(deposited_value),
             borrowed_value: unpack_decimal(borrowed_value),
-            unweighted_borrowed_value: unpack_decimal(true_borrowed_value),
+            unweighted_borrowed_value: unpack_decimal(unweighted_borrowed_value),
             borrowed_value_upper_bound: unpack_decimal(borrowed_value_upper_bound),
             allowed_borrow_value: unpack_decimal(allowed_borrow_value),
             unhealthy_borrow_value: unpack_decimal(unhealthy_borrow_value),
             super_unhealthy_borrow_value: unpack_decimal(super_unhealthy_borrow_value),
             borrowing_isolated_asset: unpack_bool(borrowing_isolated_asset)?,
+            updated_borrow_attribution_after_upgrade: unpack_bool(
+                updated_borrow_attribution_after_upgrade,
+            )?,
         })
     }
 }
@@ -682,6 +695,7 @@ mod test {
                 unhealthy_borrow_value: rand_decimal(),
                 super_unhealthy_borrow_value: rand_decimal(),
                 borrowing_isolated_asset: rng.gen(),
+                updated_borrow_attribution_after_upgrade: rng.gen(),
             };
 
             let mut packed = [0u8; OBLIGATION_LEN];

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -315,7 +315,7 @@ pub struct ObligationCollateral {
     /// Collateral market value in quote currency
     pub market_value: Decimal,
     /// How much borrow is attributed to this collateral (USD)
-    pub attributed_borrow_value: Decimal
+    pub attributed_borrow_value: Decimal,
 }
 
 impl ObligationCollateral {
@@ -481,8 +481,13 @@ impl Pack for Obligation {
         for collateral in &self.deposits {
             let deposits_flat = array_mut_ref![data_flat, offset, OBLIGATION_COLLATERAL_LEN];
             #[allow(clippy::ptr_offset_with_cast)]
-            let (deposit_reserve, deposited_amount, market_value, attributed_borrow_value, _padding_deposit) =
-                mut_array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
+            let (
+                deposit_reserve,
+                deposited_amount,
+                market_value,
+                attributed_borrow_value,
+                _padding_deposit,
+            ) = mut_array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
             deposit_reserve.copy_from_slice(collateral.deposit_reserve.as_ref());
             *deposited_amount = collateral.deposited_amount.to_le_bytes();
             pack_decimal(collateral.market_value, market_value);
@@ -568,8 +573,13 @@ impl Pack for Obligation {
         for _ in 0..deposits_len {
             let deposits_flat = array_ref![data_flat, offset, OBLIGATION_COLLATERAL_LEN];
             #[allow(clippy::ptr_offset_with_cast)]
-            let (deposit_reserve, deposited_amount, market_value, attributed_borrow_value, _padding_deposit) =
-                array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
+            let (
+                deposit_reserve,
+                deposited_amount,
+                market_value,
+                attributed_borrow_value,
+                _padding_deposit,
+            ) = array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
             deposits.push(ObligationCollateral {
                 deposit_reserve: Pubkey::new(deposit_reserve),
                 deposited_amount: u64::from_le_bytes(*deposited_amount),

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -40,6 +40,8 @@ pub struct Obligation {
     /// Risk-adjusted market value of borrows.
     /// ie sum(b.borrowed_amount * b.current_spot_price * b.borrow_weight for b in borrows)
     pub borrowed_value: Decimal,
+    /// True borrow value. Ie, not risk adjusted like "borrowed_value"
+    pub true_borrowed_value: Decimal,
     /// Risk-adjusted upper bound market value of borrows.
     /// ie sum(b.borrowed_amount * max(b.current_spot_price, b.smoothed_price) * b.borrow_weight for b in borrows)
     pub borrowed_value_upper_bound: Decimal,
@@ -431,6 +433,7 @@ impl Pack for Obligation {
             borrowed_value_upper_bound,
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
+            true_borrowed_value,
             _padding,
             deposits_len,
             borrows_len,
@@ -449,7 +452,8 @@ impl Pack for Obligation {
             16,
             1,
             16,
-            31,
+            16,
+            15,
             1,
             1,
             OBLIGATION_COLLATERAL_LEN + (OBLIGATION_LIQUIDITY_LEN * (MAX_OBLIGATION_RESERVES - 1))
@@ -471,6 +475,7 @@ impl Pack for Obligation {
             self.super_unhealthy_borrow_value,
             super_unhealthy_borrow_value,
         );
+        pack_decimal(self.true_borrowed_value, true_borrowed_value);
 
         *deposits_len = u8::try_from(self.deposits.len()).unwrap().to_le_bytes();
         *borrows_len = u8::try_from(self.borrows.len()).unwrap().to_le_bytes();
@@ -534,6 +539,7 @@ impl Pack for Obligation {
             borrowed_value_upper_bound,
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
+            true_borrowed_value,
             _padding,
             deposits_len,
             borrows_len,
@@ -552,7 +558,8 @@ impl Pack for Obligation {
             16,
             1,
             16,
-            31,
+            16,
+            15,
             1,
             1,
             OBLIGATION_COLLATERAL_LEN + (OBLIGATION_LIQUIDITY_LEN * (MAX_OBLIGATION_RESERVES - 1))
@@ -619,6 +626,7 @@ impl Pack for Obligation {
             borrows,
             deposited_value: unpack_decimal(deposited_value),
             borrowed_value: unpack_decimal(borrowed_value),
+            true_borrowed_value: unpack_decimal(true_borrowed_value),
             borrowed_value_upper_bound: unpack_decimal(borrowed_value_upper_bound),
             allowed_borrow_value: unpack_decimal(allowed_borrow_value),
             unhealthy_borrow_value: unpack_decimal(unhealthy_borrow_value),
@@ -668,6 +676,7 @@ mod test {
                 }],
                 deposited_value: rand_decimal(),
                 borrowed_value: rand_decimal(),
+                true_borrowed_value: rand_decimal(),
                 borrowed_value_upper_bound: rand_decimal(),
                 allowed_borrow_value: rand_decimal(),
                 unhealthy_borrow_value: rand_decimal(),

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -61,8 +61,8 @@ pub struct Obligation {
     pub super_unhealthy_borrow_value: Decimal,
     /// True if the obligation is currently borrowing an isolated tier asset
     pub borrowing_isolated_asset: bool,
-    /// Updated borrow attribution after upgrade. initially false when upgrading to v2.0.3
-    pub updated_borrow_attribution_after_upgrade: bool,
+    /// Obligation can be marked as closeable
+    pub closeable: bool,
 }
 
 impl Obligation {
@@ -436,7 +436,7 @@ impl Pack for Obligation {
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
             unweighted_borrowed_value,
-            updated_borrow_attribution_after_upgrade,
+            closeable,
             _padding,
             deposits_len,
             borrows_len,
@@ -480,10 +480,7 @@ impl Pack for Obligation {
             super_unhealthy_borrow_value,
         );
         pack_decimal(self.unweighted_borrowed_value, unweighted_borrowed_value);
-        pack_bool(
-            self.updated_borrow_attribution_after_upgrade,
-            updated_borrow_attribution_after_upgrade,
-        );
+        pack_bool(self.closeable, closeable);
 
         *deposits_len = u8::try_from(self.deposits.len()).unwrap().to_le_bytes();
         *borrows_len = u8::try_from(self.borrows.len()).unwrap().to_le_bytes();
@@ -548,7 +545,7 @@ impl Pack for Obligation {
             borrowing_isolated_asset,
             super_unhealthy_borrow_value,
             unweighted_borrowed_value,
-            updated_borrow_attribution_after_upgrade,
+            closeable,
             _padding,
             deposits_len,
             borrows_len,
@@ -642,9 +639,7 @@ impl Pack for Obligation {
             unhealthy_borrow_value: unpack_decimal(unhealthy_borrow_value),
             super_unhealthy_borrow_value: unpack_decimal(super_unhealthy_borrow_value),
             borrowing_isolated_asset: unpack_bool(borrowing_isolated_asset)?,
-            updated_borrow_attribution_after_upgrade: unpack_bool(
-                updated_borrow_attribution_after_upgrade,
-            )?,
+            closeable: unpack_bool(closeable)?,
         })
     }
 }
@@ -695,7 +690,7 @@ mod test {
                 unhealthy_borrow_value: rand_decimal(),
                 super_unhealthy_borrow_value: rand_decimal(),
                 borrowing_isolated_asset: rng.gen(),
-                updated_borrow_attribution_after_upgrade: rng.gen(),
+                closeable: rng.gen(),
             };
 
             let mut packed = [0u8; OBLIGATION_LEN];

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -314,6 +314,8 @@ pub struct ObligationCollateral {
     pub deposited_amount: u64,
     /// Collateral market value in quote currency
     pub market_value: Decimal,
+    /// How much borrow is attributed to this collateral (USD)
+    pub attributed_borrow_value: Decimal
 }
 
 impl ObligationCollateral {
@@ -323,6 +325,7 @@ impl ObligationCollateral {
             deposit_reserve,
             deposited_amount: 0,
             market_value: Decimal::zero(),
+            attributed_borrow_value: Decimal::zero(),
         }
     }
 
@@ -478,11 +481,12 @@ impl Pack for Obligation {
         for collateral in &self.deposits {
             let deposits_flat = array_mut_ref![data_flat, offset, OBLIGATION_COLLATERAL_LEN];
             #[allow(clippy::ptr_offset_with_cast)]
-            let (deposit_reserve, deposited_amount, market_value, _padding_deposit) =
-                mut_array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 32];
+            let (deposit_reserve, deposited_amount, market_value, attributed_borrow_value, _padding_deposit) =
+                mut_array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
             deposit_reserve.copy_from_slice(collateral.deposit_reserve.as_ref());
             *deposited_amount = collateral.deposited_amount.to_le_bytes();
             pack_decimal(collateral.market_value, market_value);
+            pack_decimal(collateral.attributed_borrow_value, attributed_borrow_value);
             offset += OBLIGATION_COLLATERAL_LEN;
         }
 
@@ -564,12 +568,13 @@ impl Pack for Obligation {
         for _ in 0..deposits_len {
             let deposits_flat = array_ref![data_flat, offset, OBLIGATION_COLLATERAL_LEN];
             #[allow(clippy::ptr_offset_with_cast)]
-            let (deposit_reserve, deposited_amount, market_value, _padding_deposit) =
-                array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 32];
+            let (deposit_reserve, deposited_amount, market_value, attributed_borrow_value, _padding_deposit) =
+                array_refs![deposits_flat, PUBKEY_BYTES, 8, 16, 16, 16];
             deposits.push(ObligationCollateral {
                 deposit_reserve: Pubkey::new(deposit_reserve),
                 deposited_amount: u64::from_le_bytes(*deposited_amount),
                 market_value: unpack_decimal(market_value),
+                attributed_borrow_value: unpack_decimal(attributed_borrow_value),
             });
             offset += OBLIGATION_COLLATERAL_LEN;
         }
@@ -643,6 +648,7 @@ mod test {
                     deposit_reserve: Pubkey::new_unique(),
                     deposited_amount: rng.gen(),
                     market_value: rand_decimal(),
+                    attributed_borrow_value: rand_decimal(),
                 }],
                 borrows: vec![ObligationLiquidity {
                     borrow_reserve: Pubkey::new_unique(),

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -41,7 +41,7 @@ pub struct Obligation {
     /// ie sum(b.borrowed_amount * b.current_spot_price * b.borrow_weight for b in borrows)
     pub borrowed_value: Decimal,
     /// True borrow value. Ie, not risk adjusted like "borrowed_value"
-    pub true_borrowed_value: Decimal,
+    pub unweighted_borrowed_value: Decimal,
     /// Risk-adjusted upper bound market value of borrows.
     /// ie sum(b.borrowed_amount * max(b.current_spot_price, b.smoothed_price) * b.borrow_weight for b in borrows)
     pub borrowed_value_upper_bound: Decimal,
@@ -475,7 +475,7 @@ impl Pack for Obligation {
             self.super_unhealthy_borrow_value,
             super_unhealthy_borrow_value,
         );
-        pack_decimal(self.true_borrowed_value, true_borrowed_value);
+        pack_decimal(self.unweighted_borrowed_value, true_borrowed_value);
 
         *deposits_len = u8::try_from(self.deposits.len()).unwrap().to_le_bytes();
         *borrows_len = u8::try_from(self.borrows.len()).unwrap().to_le_bytes();
@@ -626,7 +626,7 @@ impl Pack for Obligation {
             borrows,
             deposited_value: unpack_decimal(deposited_value),
             borrowed_value: unpack_decimal(borrowed_value),
-            true_borrowed_value: unpack_decimal(true_borrowed_value),
+            unweighted_borrowed_value: unpack_decimal(true_borrowed_value),
             borrowed_value_upper_bound: unpack_decimal(borrowed_value_upper_bound),
             allowed_borrow_value: unpack_decimal(allowed_borrow_value),
             unhealthy_borrow_value: unpack_decimal(unhealthy_borrow_value),
@@ -676,7 +676,7 @@ mod test {
                 }],
                 deposited_value: rand_decimal(),
                 borrowed_value: rand_decimal(),
-                true_borrowed_value: rand_decimal(),
+                unweighted_borrowed_value: rand_decimal(),
                 borrowed_value_upper_bound: rand_decimal(),
                 allowed_borrow_value: rand_decimal(),
                 unhealthy_borrow_value: rand_decimal(),

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -370,8 +370,15 @@ impl Reserve {
 
     /// Calculate bonus as a percentage
     /// the value will be in range [0, MAX_BONUS_PCT]
-    pub fn calculate_bonus(&self, obligation: &Obligation) -> Result<Decimal, ProgramError> {
+    pub fn calculate_bonus(&self, obligation: &Obligation) -> Result<Bonus, ProgramError> {
         if obligation.borrowed_value < obligation.unhealthy_borrow_value {
+            if obligation.closeable {
+                return Ok(Bonus {
+                    total_bonus: Decimal::zero(),
+                    protocol_liquidation_fee: Decimal::zero(),
+                });
+            }
+
             msg!("Obligation is healthy so a liquidation bonus can't be calculated");
             return Err(LendingError::ObligationHealthy.into());
         }
@@ -383,10 +390,13 @@ impl Reserve {
         // could also return the average of liquidation bonus and max liquidation bonus here, but
         // i don't think it matters
         if obligation.unhealthy_borrow_value == obligation.super_unhealthy_borrow_value {
-            return Ok(min(
-                liquidation_bonus.try_add(protocol_liquidation_fee)?,
-                Decimal::from_percent(MAX_BONUS_PCT),
-            ));
+            return Ok(Bonus {
+                total_bonus: min(
+                    liquidation_bonus.try_add(protocol_liquidation_fee)?,
+                    Decimal::from_percent(MAX_BONUS_PCT),
+                ),
+                protocol_liquidation_fee,
+            });
         }
 
         // safety:
@@ -415,7 +425,10 @@ impl Reserve {
             .try_add(weight.try_mul(max_liquidation_bonus.try_sub(liquidation_bonus)?)?)?
             .try_add(protocol_liquidation_fee)?;
 
-        Ok(min(bonus, Decimal::from_percent(MAX_BONUS_PCT)))
+        Ok(Bonus {
+            total_bonus: min(bonus, Decimal::from_percent(MAX_BONUS_PCT)),
+            protocol_liquidation_fee,
+        })
     }
 
     /// Liquidate some or all of an unhealthy obligation
@@ -425,8 +438,14 @@ impl Reserve {
         obligation: &Obligation,
         liquidity: &ObligationLiquidity,
         collateral: &ObligationCollateral,
+        bonus: &Bonus,
     ) -> Result<CalculateLiquidationResult, ProgramError> {
-        let bonus_rate = self.calculate_bonus(obligation)?.try_add(Decimal::one())?;
+        if bonus.total_bonus > Decimal::from_percent(MAX_BONUS_PCT) {
+            msg!("Bonus rate cannot exceed maximum bonus rate");
+            return Err(LendingError::InvalidAmount.into());
+        }
+
+        let bonus_rate = bonus.total_bonus.try_add(Decimal::one())?;
 
         let max_amount = if amount_to_liquidate == u64::MAX {
             liquidity.borrowed_amount_wads
@@ -517,29 +536,33 @@ impl Reserve {
             settle_amount,
             repay_amount,
             withdraw_amount,
-            bonus_rate,
         })
     }
 
     /// Calculate protocol cut of liquidation bonus always at least 1 lamport
-    /// the bonus rate is always >=1 and includes both liquidator bonus and protocol fee.
+    /// the bonus rate is always <= MAX_BONUS_PCT
     /// the bonus rate has to be passed into this function because bonus calculations are dynamic
     /// and can't be recalculated after liquidation.
     pub fn calculate_protocol_liquidation_fee(
         &self,
         amount_liquidated: u64,
-        bonus_rate: Decimal,
+        bonus: &Bonus,
     ) -> Result<u64, ProgramError> {
+        if bonus.total_bonus > Decimal::from_percent(MAX_BONUS_PCT) {
+            msg!("Bonus rate cannot exceed maximum bonus rate");
+            return Err(LendingError::InvalidAmount.into());
+        }
+
         let amount_liquidated_wads = Decimal::from(amount_liquidated);
-        let nonbonus_amount = amount_liquidated_wads.try_div(bonus_rate)?;
-        // After deploying must update all reserves to set liquidation fee then redeploy with this line instead of hardcode
-        let protocol_fee = std::cmp::max(
+        let nonbonus_amount =
+            amount_liquidated_wads.try_div(Decimal::one().try_add(bonus.total_bonus)?)?;
+
+        Ok(std::cmp::max(
             nonbonus_amount
-                .try_mul(Decimal::from_deca_bps(self.config.protocol_liquidation_fee))?
+                .try_mul(bonus.protocol_liquidation_fee)?
                 .try_ceil_u64()?,
             1,
-        );
-        Ok(protocol_fee)
+        ))
     }
 
     /// Calculate protocol fee redemption accounting for availible liquidity and accumulated fees
@@ -601,9 +624,17 @@ pub struct CalculateLiquidationResult {
     pub repay_amount: u64,
     /// Amount of collateral to withdraw in exchange for repay amount
     pub withdraw_amount: u64,
-    /// Liquidator bonus as a percentage, including the protocol fee
-    /// always greater than or equal to 1.
-    pub bonus_rate: Decimal,
+}
+
+/// Bonus
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bonus {
+    /// Total bonus (liquidator bonus + protocol liquidation fee). 0 <= x <= MAX_BONUS_PCT
+    /// eg if the total bonus is 5%, this value is 0.05
+    pub total_bonus: Decimal,
+    /// protocol liquidation fee pct. 0 <= x <= reserve.config.protocol_liquidation_fee / 10
+    /// eg if the protocol liquidation fee is 1%, this value is 0.01
+    pub protocol_liquidation_fee: Decimal,
 }
 
 /// Reserve liquidity
@@ -943,8 +974,10 @@ pub struct ReserveConfig {
     pub scaled_price_offset_bps: i64,
     /// Extra oracle. Only used to limit borrows and withdrawals.
     pub extra_oracle_pubkey: Option<Pubkey>,
-    /// Attributed Borrow limit in USD
-    pub attributed_borrow_limit: u64,
+    /// Open Attributed Borrow limit in USD
+    pub attributed_borrow_limit_open: u64,
+    /// Close Attributed Borrow limit in USD
+    pub attributed_borrow_limit_close: u64,
 }
 
 /// validates reserve configs
@@ -1041,6 +1074,11 @@ pub fn validate_reserve_config(config: ReserveConfig) -> ProgramResult {
             MIN_SCALED_PRICE_OFFSET_BPS,
             MAX_SCALED_PRICE_OFFSET_BPS
         );
+        return Err(LendingError::InvalidConfig.into());
+    }
+
+    if config.attributed_borrow_limit_open > config.attributed_borrow_limit_close {
+        msg!("open attributed borrow limit must be <= close attributed borrow limit");
         return Err(LendingError::InvalidConfig.into());
     }
 
@@ -1235,7 +1273,8 @@ impl Pack for Reserve {
             liquidity_extra_market_price_flag,
             liquidity_extra_market_price,
             attributed_borrow_value,
-            config_attributed_borrow_limit,
+            config_attributed_borrow_limit_open,
+            config_attributed_borrow_limit_close,
             _padding,
         ) = mut_array_refs![
             output,
@@ -1285,7 +1324,8 @@ impl Pack for Reserve {
             16,
             16,
             8,
-            57
+            8,
+            49
         ];
 
         // reserve
@@ -1365,7 +1405,10 @@ impl Pack for Reserve {
         *config_added_borrow_weight_bps = self.config.added_borrow_weight_bps.to_le_bytes();
         *config_max_liquidation_bonus = self.config.max_liquidation_bonus.to_le_bytes();
         *config_max_liquidation_threshold = self.config.max_liquidation_threshold.to_le_bytes();
-        *config_attributed_borrow_limit = self.config.attributed_borrow_limit.to_le_bytes();
+        *config_attributed_borrow_limit_open =
+            self.config.attributed_borrow_limit_open.to_le_bytes();
+        *config_attributed_borrow_limit_close =
+            self.config.attributed_borrow_limit_close.to_le_bytes();
 
         pack_decimal(self.attributed_borrow_value, attributed_borrow_value);
     }
@@ -1420,7 +1463,8 @@ impl Pack for Reserve {
             liquidity_extra_market_price_flag,
             liquidity_extra_market_price,
             attributed_borrow_value,
-            config_attributed_borrow_limit,
+            config_attributed_borrow_limit_open,
+            config_attributed_borrow_limit_close,
             _padding,
         ) = array_refs![
             input,
@@ -1470,7 +1514,8 @@ impl Pack for Reserve {
             16,
             16,
             8,
-            57
+            8,
+            49
         ];
 
         let version = u8::from_le_bytes(*version);
@@ -1576,10 +1621,19 @@ impl Pack for Reserve {
                     Some(Pubkey::new_from_array(*config_extra_oracle_pubkey))
                 },
                 // this field is added in v2.0.3 and we will never set it to zero. only time it'll
+                // the following two fields are added in v2.0.3 and we will never set it to zero. only time they will
                 // be zero is when we upgrade from v2.0.2 to v2.0.3. in that case, the correct
                 // thing to do is set the value to u64::MAX.
-                attributed_borrow_limit: {
-                    let value = u64::from_le_bytes(*config_attributed_borrow_limit);
+                attributed_borrow_limit_open: {
+                    let value = u64::from_le_bytes(*config_attributed_borrow_limit_open);
+                    if value == 0 {
+                        u64::MAX
+                    } else {
+                        value
+                    }
+                },
+                attributed_borrow_limit_close: {
+                    let value = u64::from_le_bytes(*config_attributed_borrow_limit_close);
                     if value == 0 {
                         u64::MAX
                     } else {
@@ -1677,7 +1731,8 @@ mod test {
                     reserve_type: ReserveType::from_u8(rng.gen::<u8>() % 2).unwrap(),
                     scaled_price_offset_bps: rng.gen(),
                     extra_oracle_pubkey,
-                    attributed_borrow_limit: rng.gen(),
+                    attributed_borrow_limit_open: rng.gen(),
+                    attributed_borrow_limit_close: rng.gen(),
                 },
                 rate_limiter: rand_rate_limiter(),
                 attributed_borrow_value: rand_decimal(),
@@ -2080,7 +2135,7 @@ mod test {
 
     #[test]
     fn calculate_protocol_liquidation_fee() {
-        let mut reserve = Reserve {
+        let reserve = Reserve {
             config: ReserveConfig {
                 protocol_liquidation_fee: 10,
                 ..Default::default()
@@ -2090,17 +2145,54 @@ mod test {
 
         assert_eq!(
             reserve
-                .calculate_protocol_liquidation_fee(105, Decimal::from_percent(105))
+                .calculate_protocol_liquidation_fee(
+                    105,
+                    &Bonus {
+                        total_bonus: Decimal::from_percent(5),
+                        protocol_liquidation_fee: Decimal::from_percent(1),
+                    }
+                )
                 .unwrap(),
             1
         );
 
-        reserve.config.protocol_liquidation_fee = 20;
         assert_eq!(
             reserve
-                .calculate_protocol_liquidation_fee(105, Decimal::from_percent(105))
+                .calculate_protocol_liquidation_fee(
+                    105,
+                    &Bonus {
+                        total_bonus: Decimal::from_percent(5),
+                        protocol_liquidation_fee: Decimal::from_percent(2),
+                    }
+                )
                 .unwrap(),
             2
+        );
+
+        assert_eq!(
+            reserve
+                .calculate_protocol_liquidation_fee(
+                    10000,
+                    &Bonus {
+                        total_bonus: Decimal::from_percent(5),
+                        protocol_liquidation_fee: Decimal::from_percent(0),
+                    }
+                )
+                .unwrap(),
+            1
+        );
+
+        assert_eq!(
+            reserve
+                .calculate_protocol_liquidation_fee(
+                    10000,
+                    &Bonus {
+                        total_bonus: Decimal::from_percent(1),
+                        protocol_liquidation_fee: Decimal::from_percent(1),
+                    }
+                )
+                .unwrap(),
+            100
         );
     }
 
@@ -2287,6 +2379,8 @@ mod test {
             Just(ReserveConfigTestCase {
                 config: ReserveConfig {
                     scaled_price_offset_bps: 1999,
+                    attributed_borrow_limit_open: 50,
+                    attributed_borrow_limit_close: 51,
                     ..ReserveConfig::default()
                 },
                 result: Ok(())
@@ -2304,6 +2398,14 @@ mod test {
                     ..ReserveConfig::default()
                 },
                 result: Ok(())
+            }),
+            Just(ReserveConfigTestCase {
+                config: ReserveConfig {
+                    attributed_borrow_limit_open: 51,
+                    attributed_borrow_limit_close: 50,
+                    ..ReserveConfig::default()
+                },
+                result: Err(LendingError::InvalidConfig.into()),
             })
         ]
     }
@@ -2320,12 +2422,13 @@ mod test {
         borrowed_value: Decimal,
         unhealthy_borrow_value: Decimal,
         super_unhealthy_borrow_value: Decimal,
+        closeable: bool,
 
         liquidation_bonus: u8,
         max_liquidation_bonus: u8,
         protocol_liquidation_fee: u8,
 
-        result: Result<Decimal, ProgramError>,
+        result: Result<Bonus, ProgramError>,
     }
 
     fn calculate_bonus_test_cases() -> impl Strategy<Value = LiquidationBonusTestCase> {
@@ -2335,73 +2438,130 @@ mod test {
                 borrowed_value: Decimal::from(100u64),
                 unhealthy_borrow_value: Decimal::from(101u64),
                 super_unhealthy_borrow_value: Decimal::from(150u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
                 result: Err(LendingError::ObligationHealthy.into()),
             }),
+            // healthy but closeable
+            Just(LiquidationBonusTestCase {
+                borrowed_value: Decimal::from(100u64),
+                unhealthy_borrow_value: Decimal::from(101u64),
+                super_unhealthy_borrow_value: Decimal::from(150u64),
+                closeable: true,
+                liquidation_bonus: 10,
+                max_liquidation_bonus: 20,
+                protocol_liquidation_fee: 10,
+                result: Ok(Bonus {
+                    total_bonus: Decimal::zero(),
+                    protocol_liquidation_fee: Decimal::zero()
+                }),
+            }),
+            // unhealthy and also closeable
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(100u64),
                 unhealthy_borrow_value: Decimal::from(100u64),
                 super_unhealthy_borrow_value: Decimal::from(150u64),
+                closeable: true,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(11))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(11),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
+            }),
+            Just(LiquidationBonusTestCase {
+                borrowed_value: Decimal::from(100u64),
+                unhealthy_borrow_value: Decimal::from(100u64),
+                super_unhealthy_borrow_value: Decimal::from(150u64),
+                closeable: false,
+                liquidation_bonus: 10,
+                max_liquidation_bonus: 20,
+                protocol_liquidation_fee: 10,
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(11),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(100u64),
                 unhealthy_borrow_value: Decimal::from(50u64),
                 super_unhealthy_borrow_value: Decimal::from(150u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(16))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(16),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(100u64),
                 unhealthy_borrow_value: Decimal::from(50u64),
                 super_unhealthy_borrow_value: Decimal::from(100u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(21))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(21),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(200u64),
                 unhealthy_borrow_value: Decimal::from(50u64),
                 super_unhealthy_borrow_value: Decimal::from(100u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(21))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(21),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(60u64),
                 unhealthy_borrow_value: Decimal::from(50u64),
                 super_unhealthy_borrow_value: Decimal::from(50u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 20,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(11))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(11),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(60u64),
                 unhealthy_borrow_value: Decimal::from(40u64),
                 super_unhealthy_borrow_value: Decimal::from(60u64),
+                closeable: false,
                 liquidation_bonus: 10,
                 max_liquidation_bonus: 30,
                 protocol_liquidation_fee: 10,
-                result: Ok(Decimal::from_percent(25))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(25),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                }),
             }),
             Just(LiquidationBonusTestCase {
                 borrowed_value: Decimal::from(60u64),
                 unhealthy_borrow_value: Decimal::from(40u64),
                 super_unhealthy_borrow_value: Decimal::from(60u64),
+                closeable: false,
                 liquidation_bonus: 30,
                 max_liquidation_bonus: 30,
                 protocol_liquidation_fee: 30,
-                result: Ok(Decimal::from_percent(25))
+                result: Ok(Bonus {
+                    total_bonus: Decimal::from_percent(25),
+                    protocol_liquidation_fee: Decimal::from_percent(3)
+                }),
             }),
         ]
     }
@@ -2423,6 +2583,7 @@ mod test {
                 borrowed_value: test_case.borrowed_value,
                 unhealthy_borrow_value: test_case.unhealthy_borrow_value,
                 super_unhealthy_borrow_value: test_case.super_unhealthy_borrow_value,
+                closeable: test_case.closeable,
                 ..Obligation::default()
             };
 
@@ -2439,6 +2600,7 @@ mod test {
         deposit_market_value: Decimal,
         borrow_amount: u64,
         borrow_market_value: Decimal,
+        bonus: Bonus,
         liquidation_result: CalculateLiquidationResult,
     }
 
@@ -2459,6 +2621,10 @@ mod test {
                 deposit_market_value: Decimal::from(100u64),
                 borrow_amount: 800,
                 borrow_market_value: Decimal::from(80u64),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: close_factor.try_mul(Decimal::from(800u64)).unwrap(),
                     repay_amount: close_factor
@@ -2473,7 +2639,6 @@ mod test {
                         .unwrap()
                         .try_floor_u64()
                         .unwrap(),
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // collateral market value == liquidation_value
@@ -2484,12 +2649,15 @@ mod test {
                 deposit_market_value: Decimal::from(
                     (8000 * LIQUIDATION_CLOSE_FACTOR as u64) * 105 / 10000
                 ),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from((8000 * LIQUIDATION_CLOSE_FACTOR as u64) / 100),
                     repay_amount: (8000 * LIQUIDATION_CLOSE_FACTOR as u64) / 100,
                     withdraw_amount: (8000 * LIQUIDATION_CLOSE_FACTOR as u64) * 105 / 10000,
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // collateral market value < liquidation_value
@@ -2502,6 +2670,10 @@ mod test {
                 deposit_market_value: Decimal::from(
                     (8000 * LIQUIDATION_CLOSE_FACTOR as u64) * 105 / 10000 / 2
                 ),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(
@@ -2509,7 +2681,6 @@ mod test {
                     ),
                     repay_amount: (8000 * LIQUIDATION_CLOSE_FACTOR as u64) / 100 / 2,
                     withdraw_amount: (8000 * LIQUIDATION_CLOSE_FACTOR as u64) * 105 / 10000 / 2,
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // dust ObligationLiquidity where collateral market value > liquidation value
@@ -2518,13 +2689,16 @@ mod test {
                 borrow_market_value: Decimal::from_percent(50),
                 deposit_amount: 100,
                 deposit_market_value: Decimal::from(1u64),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(100u64),
                     repay_amount: 100,
                     // $0.5 * 1.05 = $0.525
                     withdraw_amount: 52,
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // dust ObligationLiquidity where collateral market value == liquidation value
@@ -2533,12 +2707,15 @@ mod test {
                 borrow_market_value: Decimal::from(1u64),
                 deposit_amount: 1000,
                 deposit_market_value: Decimal::from_percent(105),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(1u64),
                     repay_amount: 1,
                     withdraw_amount: 1000,
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // dust ObligationLiquidity where collateral market value < liquidation value
@@ -2547,12 +2724,15 @@ mod test {
                 borrow_market_value: Decimal::one(),
                 deposit_amount: 10,
                 deposit_market_value: Decimal::from_bps(5250), // $0.525
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(5u64),
                     repay_amount: 5,
                     withdraw_amount: 10,
-                    bonus_rate: liquidation_bonus
                 },
             }),
             // dust ObligationLiquidity where collateral market value > liquidation value and the
@@ -2562,12 +2742,32 @@ mod test {
                 borrow_market_value: Decimal::one(),
                 deposit_amount: 1,
                 deposit_market_value: Decimal::from(10u64),
+                bonus: Bonus {
+                    total_bonus: Decimal::from_percent(5),
+                    protocol_liquidation_fee: Decimal::from_percent(1)
+                },
 
                 liquidation_result: CalculateLiquidationResult {
                     settle_amount: Decimal::from(1u64),
                     repay_amount: 1,
                     withdraw_amount: 1,
-                    bonus_rate: liquidation_bonus
+                },
+            }),
+            // zero bonus rate
+            Just(LiquidationTestCase {
+                borrow_amount: 100,
+                borrow_market_value: Decimal::from(100u64),
+                deposit_amount: 100,
+                deposit_market_value: Decimal::from(100u64),
+                bonus: Bonus {
+                    total_bonus: Decimal::zero(),
+                    protocol_liquidation_fee: Decimal::zero()
+                },
+
+                liquidation_result: CalculateLiquidationResult {
+                    settle_amount: Decimal::from(20u64),
+                    repay_amount: 20,
+                    withdraw_amount: 20,
                 },
             }),
         ]
@@ -2577,11 +2777,7 @@ mod test {
         #[test]
         fn calculate_liquidation(test_case in calculate_liquidation_test_cases()) {
             let reserve = Reserve {
-                config: ReserveConfig {
-                    liquidation_bonus: 5,
-                    max_liquidation_bonus: 5,
-                    ..ReserveConfig::default()
-                },
+                config: ReserveConfig::default(),
                 ..Reserve::default()
             };
 
@@ -2606,7 +2802,12 @@ mod test {
 
             assert_eq!(
                 reserve.calculate_liquidation(
-                    u64::MAX, &obligation, &obligation.borrows[0], &obligation.deposits[0]).unwrap(),
+                    u64::MAX,
+                    &obligation,
+                    &obligation.borrows[0],
+                    &obligation.deposits[0],
+                    &test_case.bonus,
+                ).unwrap(),
                 test_case.liquidation_result);
         }
     }

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -58,6 +58,8 @@ pub struct Reserve {
     pub config: ReserveConfig,
     /// Outflow Rate Limiter (denominated in tokens)
     pub rate_limiter: RateLimiter,
+    /// Attributed borrows in USD
+    pub attributed_borrow_value: Decimal,
 }
 
 impl Reserve {
@@ -77,6 +79,7 @@ impl Reserve {
         self.collateral = params.collateral;
         self.config = params.config;
         self.rate_limiter = RateLimiter::new(params.rate_limiter_config, params.current_slot);
+        self.attributed_borrow_value = Decimal::zero();
     }
 
     /// get borrow weight. Guaranteed to be greater than 1
@@ -1229,6 +1232,7 @@ impl Pack for Reserve {
             config_extra_oracle_pubkey,
             liquidity_extra_market_price_flag,
             liquidity_extra_market_price,
+            attributed_borrow_value,
             _padding,
         ) = mut_array_refs![
             output,
@@ -1276,7 +1280,8 @@ impl Pack for Reserve {
             32,
             1,
             16,
-            81
+            16,
+            65
         ];
 
         // reserve
@@ -1356,6 +1361,8 @@ impl Pack for Reserve {
         *config_added_borrow_weight_bps = self.config.added_borrow_weight_bps.to_le_bytes();
         *config_max_liquidation_bonus = self.config.max_liquidation_bonus.to_le_bytes();
         *config_max_liquidation_threshold = self.config.max_liquidation_threshold.to_le_bytes();
+
+        pack_decimal(self.attributed_borrow_value, attributed_borrow_value);
     }
 
     /// Unpacks a byte buffer into a [ReserveInfo](struct.ReserveInfo.html).
@@ -1407,6 +1414,7 @@ impl Pack for Reserve {
             config_extra_oracle_pubkey,
             liquidity_extra_market_price_flag,
             liquidity_extra_market_price,
+            attributed_borrow_value,
             _padding,
         ) = array_refs![
             input,
@@ -1454,7 +1462,8 @@ impl Pack for Reserve {
             32,
             1,
             16,
-            81
+            16,
+            65
         ];
 
         let version = u8::from_le_bytes(*version);
@@ -1561,6 +1570,7 @@ impl Pack for Reserve {
                 },
             },
             rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
+            attributed_borrow_value: unpack_decimal(attributed_borrow_value),
         })
     }
 }
@@ -1651,6 +1661,7 @@ mod test {
                     extra_oracle_pubkey,
                 },
                 rate_limiter: rand_rate_limiter(),
+                attributed_borrow_value: rand_decimal(),
             };
 
             let mut packed = [0u8; Reserve::LEN];
@@ -2559,7 +2570,8 @@ mod test {
                 deposits: vec![ObligationCollateral {
                     deposit_reserve: Pubkey::new_unique(),
                     deposited_amount: test_case.deposit_amount,
-                    market_value: test_case.deposit_market_value
+                    market_value: test_case.deposit_market_value,
+                    attributed_borrow_value: test_case.borrow_market_value,
                 }],
                 borrows: vec![ObligationLiquidity {
                     borrow_reserve: Pubkey::new_unique(),

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -1575,7 +1575,17 @@ impl Pack for Reserve {
                 } else {
                     Some(Pubkey::new_from_array(*config_extra_oracle_pubkey))
                 },
-                attributed_borrow_limit: u64::from_le_bytes(*config_attributed_borrow_limit),
+                // this field is added in v2.0.3 and we will never set it to zero. only time it'll
+                // be zero is when we upgrade from v2.0.2 to v2.0.3. in that case, the correct
+                // thing to do is set the value to u64::MAX.
+                attributed_borrow_limit: {
+                    let value = u64::from_le_bytes(*config_attributed_borrow_limit);
+                    if value == 0 {
+                        u64::MAX
+                    } else {
+                        value
+                    }
+                },
             },
             rate_limiter: RateLimiter::unpack_from_slice(rate_limiter)?,
             attributed_borrow_value: unpack_decimal(attributed_borrow_value),

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -944,7 +944,7 @@ pub struct ReserveConfig {
     /// Extra oracle. Only used to limit borrows and withdrawals.
     pub extra_oracle_pubkey: Option<Pubkey>,
     /// Attributed Borrow limit in USD
-    pub attributed_borrow_limit: u64
+    pub attributed_borrow_limit: u64,
 }
 
 /// validates reserve configs


### PR DESCRIPTION
Solend V2 introduces collateralization limits, which are global limits on how much can be borrowed against an asset. For example, a collateralization limit of $20M for SOL means only $20M of borrows can be secured by SOL collateral. 

If the collateralization limit for an asset is hit, increasing borrows against that asset (via borrows or withdraws) is not allowed.  Additionally, any obligation that violates this limit can be marked as closeable by the lending market owner or risk authority. A closeable obligation can be liquidated without penalty. 


Comments:
- borrow attribution values are not updated in the deposit instruction, which is technically incorrect. this can cause staleness issues if multiple txns are in the same slot. eg [A refresh, B deposit, A borrow]. the deposit might cause the borrow to be invalid wrt attribution limits, but the program will still allow it. the solution is to update the borrow attribution limits in deposit, but im not sure if we wanna do that. 

Compute unit usage of refresh obligation before and after changes.


#Deposits | before | after | delta
-- | -- | -- | --
9 | 161474 | 195305 | 33831
8 | 145275 | 175341 | 30066
7 | 129076 | 155393 | 26317
6 | 112881 | 135435 | 22554
5 | 96682 | 115480 | 18798
4 | 80487 | 95529 | 15042
3 | 64288 | 75577 | 11289
2 | 48093 | 55623 | 7530
1 | 31894 | 35181 | 3287
