### PR TITLE
Fix failing CI due to missing libssl1.1 dep

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -7,7 +7,6 @@ sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-1
 sudo apt-get update
 sudo apt-get install -y openssl --allow-unauthenticated
 sudo apt-get install -y libssl-dev --allow-unauthenticated
-sudo apt-get install -y libssl1.1 --allow-unauthenticated
 sudo apt-get install -y libudev-dev
 sudo apt-get install -y binutils-dev
 sudo apt-get install -y libunwind-dev


### PR DESCRIPTION
I've been seeing a CI failure:

```
+ sudo apt-get install -y libssl1.1 --allow-unauthenticated
Reading package lists...
Building dependency tree...
Reading state information...
Package libssl1.1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libssl1.1' has no installation candidate
```

I removed the culprit and tried to run the CI to confirm it wasn't needed: <https://github.com/solendprotocol/solana-program-library/actions/runs/13541041922>