### PR TITLE
[Liquidity Mining] Adding claim ix & connecting all ixs to account logic (6)

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -3488,6 +3488,31 @@ fn spl_token_burn(params: TokenBurnParams<'_, '_>) -> ProgramResult {
     result.map_err(|_| LendingError::TokenBurnFailed.into())
 }
 
+/// Issue a spl_token `CloseAccount` instruction.
+#[inline(always)]
+fn spl_token_close_account(params: TokenCloseAccountParams<'_, '_>) -> ProgramResult {
+    let TokenCloseAccountParams {
+        account,
+        destination,
+        authority,
+        token_program,
+        authority_signer_seeds,
+    } = params;
+    let result = invoke_optionally_signed(
+        &spl_token::instruction::close_account(
+            token_program.key,
+            account.key,
+            destination.key,
+            authority.key,
+            &[],
+        )?,
+        &[account, destination, authority, token_program],
+        authority_signer_seeds,
+    );
+
+    result.map_err(|_| LendingError::CloseTokenAccountFailed.into())
+}
+
 fn is_cpi_call(
     program_id: &Pubkey,
     current_index: usize,
@@ -3555,6 +3580,14 @@ struct TokenBurnParams<'a: 'b, 'b> {
     mint: AccountInfo<'a>,
     source: AccountInfo<'a>,
     amount: u64,
+    authority: AccountInfo<'a>,
+    authority_signer_seeds: &'b [&'b [u8]],
+    token_program: AccountInfo<'a>,
+}
+
+struct TokenCloseAccountParams<'a: 'b, 'b> {
+    account: AccountInfo<'a>,
+    destination: AccountInfo<'a>,
     authority: AccountInfo<'a>,
     authority_signer_seeds: &'b [&'b [u8]],
     token_program: AccountInfo<'a>,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -211,7 +211,7 @@ pub fn process_instruction(
             token_amount,
         } => {
             msg!("Instruction: Add Pool Reward");
-            liquidity_mining::process_add_pool_reward(
+            liquidity_mining::add_pool_reward::process(
                 program_id,
                 position_kind,
                 start_time_secs,
@@ -225,7 +225,7 @@ pub fn process_instruction(
             pool_reward_index,
         } => {
             msg!("Instruction: Cancel Pool Reward");
-            liquidity_mining::process_cancel_pool_reward(
+            liquidity_mining::cancel_pool_reward::process(
                 program_id,
                 position_kind,
                 pool_reward_index,
@@ -237,18 +237,22 @@ pub fn process_instruction(
             pool_reward_index,
         } => {
             msg!("Instruction: Close Pool Reward");
-            liquidity_mining::process_close_pool_reward(
+            liquidity_mining::close_pool_reward::process(
                 program_id,
                 position_kind,
                 pool_reward_index,
                 accounts,
             )
         }
+        LendingInstruction::ClaimReward => {
+            msg!("Instruction: Claim Reward");
+            liquidity_mining::claim_user_reward::process(program_id, accounts)
+        }
 
         // temporary ix for upgrade
         LendingInstruction::UpgradeReserveToV2_1_0 => {
             msg!("Instruction: Upgrade Reserve to v2.1.0");
-            liquidity_mining::upgrade_reserve(program_id, accounts)
+            liquidity_mining::upgrade_reserve::process(program_id, accounts)
         }
     }
 }
@@ -3484,31 +3488,6 @@ fn spl_token_burn(params: TokenBurnParams<'_, '_>) -> ProgramResult {
     result.map_err(|_| LendingError::TokenBurnFailed.into())
 }
 
-/// Issue a spl_token `CloseAccount` instruction.
-#[inline(always)]
-fn spl_token_close_account(params: TokenCloseAccountParams<'_, '_>) -> ProgramResult {
-    let TokenCloseAccountParams {
-        account,
-        destination,
-        authority,
-        token_program,
-        authority_signer_seeds,
-    } = params;
-    let result = invoke_optionally_signed(
-        &spl_token::instruction::close_account(
-            token_program.key,
-            account.key,
-            destination.key,
-            authority.key,
-            &[],
-        )?,
-        &[account, destination, authority, token_program],
-        authority_signer_seeds,
-    );
-
-    result.map_err(|_| LendingError::CloseTokenAccountFailed.into())
-}
-
 fn is_cpi_call(
     program_id: &Pubkey,
     current_index: usize,
@@ -3576,14 +3555,6 @@ struct TokenBurnParams<'a: 'b, 'b> {
     mint: AccountInfo<'a>,
     source: AccountInfo<'a>,
     amount: u64,
-    authority: AccountInfo<'a>,
-    authority_signer_seeds: &'b [&'b [u8]],
-    token_program: AccountInfo<'a>,
-}
-
-struct TokenCloseAccountParams<'a: 'b, 'b> {
-    account: AccountInfo<'a>,
-    destination: AccountInfo<'a>,
     authority: AccountInfo<'a>,
     authority_signer_seeds: &'b [&'b [u8]],
     token_program: AccountInfo<'a>,

--- a/token-lending/program/src/processor/liquidity_mining.rs
+++ b/token-lending/program/src/processor/liquidity_mining.rs
@@ -11,291 +11,27 @@
 //! - [cancel_pool_reward] (TODO: add bpf tests)
 //! - [close_pool_reward] (TODO: add bpf tests)
 //!
+//! There is an ix related to migration:
+//! - [upgrade_reserve] (TODO: add bpf tests)
+//!
+//! There is one user ix:
+//! - [claim_user_reward] (TODO: add bpf tests)
+//!
 //! [suilend-lm]: https://github.com/solendprotocol/suilend/blob/dc53150416f352053ac3acbb320ee143409c4a5d/contracts/suilend/sources/liquidity_mining.move#L2
 
-use crate::processor::{
-    assert_rent_exempt, spl_token_close_account, spl_token_init_account, spl_token_transfer,
-    TokenCloseAccountParams, TokenInitializeAccountParams, TokenTransferParams,
-};
-use add_pool_reward::{AddPoolRewardAccounts, AddPoolRewardParams};
-use cancel_pool_reward::{CancelPoolRewardAccounts, CancelPoolRewardParams};
-use close_pool_reward::{ClosePoolRewardAccounts, ClosePoolRewardParams};
+pub(crate) mod add_pool_reward;
+pub(crate) mod cancel_pool_reward;
+pub(crate) mod claim_user_reward;
+pub(crate) mod close_pool_reward;
+pub(crate) mod upgrade_reserve;
+
 use solana_program::program_pack::Pack;
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    msg,
-    program::invoke,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_instruction,
-    sysvar::Sysvar,
-};
-use solend_sdk::state::discriminator::AccountDiscriminator;
+use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
 use solend_sdk::{
     error::LendingError,
-    state::{LendingMarket, PositionKind, Reserve},
+    state::{LendingMarket, Reserve},
 };
 use spl_token::state::Account as TokenAccount;
-use std::convert::TryInto;
-use upgrade_reserve::UpgradeReserveAccounts;
-
-/// # Accounts
-///
-/// See [add_pool_reward::AddPoolRewardAccounts::from_unchecked_iter] for a list
-/// of accounts and their constraints.
-///
-/// # Effects
-///
-/// 1. Initializes a new reward vault account and transfers
-///    `reward_token_amount` tokens from the `reward_token_source` account to
-///     the new reward vault account.
-/// 2. Finds an empty slot in the [Reserve]'s LM reward vector and adds it there.
-/// 3. Packs all changes into account buffers.
-pub(crate) fn process_add_pool_reward(
-    program_id: &Pubkey,
-    position_kind: PositionKind,
-    start_time_secs: u64,
-    end_time_secs: u64,
-    reward_token_amount: u64,
-    accounts: &[AccountInfo],
-) -> ProgramResult {
-    let params = AddPoolRewardParams::new(
-        position_kind,
-        start_time_secs,
-        end_time_secs,
-        reward_token_amount,
-    )?;
-
-    let accounts =
-        AddPoolRewardAccounts::from_unchecked_iter(program_id, &params, &mut accounts.iter())?;
-
-    // 1.
-
-    spl_token_init_account(TokenInitializeAccountParams {
-        account: accounts.reward_token_vault_info.clone(),
-        mint: accounts.reward_mint_info.clone(),
-        owner: accounts.reward_authority_info.clone(),
-        rent: accounts.rent_info.clone(),
-        token_program: accounts.token_program_info.clone(),
-    })?;
-    let rent = &Rent::from_account_info(accounts.rent_info)?;
-    assert_rent_exempt(rent, accounts.reward_token_vault_info)?;
-
-    spl_token_transfer(TokenTransferParams {
-        source: accounts.reward_token_source_info.clone(),
-        destination: accounts.reward_token_vault_info.clone(),
-        amount: params.reward_token_amount,
-        authority: accounts.lending_market_owner_info.clone(),
-        authority_signer_seeds: &[],
-        token_program: accounts.token_program_info.clone(),
-    })?;
-
-    // 2.
-
-    todo!("accounts.reserve.add_pool_reward(..)");
-
-    // 3.
-
-    Reserve::pack(
-        *accounts.reserve,
-        &mut accounts.reserve_info.data.borrow_mut(),
-    )?;
-
-    Ok(())
-}
-
-/// # Accounts
-///
-/// See [cancel_pool_reward::CancelPoolRewardAccounts::from_unchecked_iter] for a list
-/// of accounts and their constraints.
-///
-/// # Effects
-///
-/// 1. Cancels any further reward emission, effectively setting end time to now.
-/// 2. Transfers any unallocated rewards to the `reward_token_destination` account.
-/// 3. Packs all changes into account buffers.
-pub(crate) fn process_cancel_pool_reward(
-    program_id: &Pubkey,
-    position_kind: PositionKind,
-    pool_reward_index: u64,
-    accounts: &[AccountInfo],
-) -> ProgramResult {
-    let params = CancelPoolRewardParams::new(position_kind, pool_reward_index);
-
-    let accounts =
-        CancelPoolRewardAccounts::from_unchecked_iter(program_id, &params, &mut accounts.iter())?;
-
-    // 1.
-
-    let unallocated_rewards = todo!("accounts.reserve.cancel_pool_reward(..)");
-
-    // 2.
-
-    spl_token_transfer(TokenTransferParams {
-        source: accounts.reward_token_vault_info.clone(),
-        destination: accounts.reward_token_destination_info.clone(),
-        amount: unallocated_rewards,
-        authority: accounts.reward_authority_info.clone(),
-        authority_signer_seeds: &reward_vault_authority_seeds(
-            accounts.lending_market_info.key,
-            accounts.reserve_info.key,
-            accounts.reward_mint_info.key,
-        ),
-        token_program: accounts.token_program_info.clone(),
-    })?;
-
-    // 3.
-
-    Reserve::pack(
-        *accounts.reserve,
-        &mut accounts.reserve_info.data.borrow_mut(),
-    )?;
-
-    Ok(())
-}
-
-/// # Accounts
-///
-/// See [close_pool_reward::ClosePoolRewardAccounts::from_unchecked_iter] for a list
-/// of accounts and their constraints.
-///
-/// # Effects
-///
-/// 1. Closes reward in the [Reserve] account if all users have claimed.
-/// 2. Transfers any unallocated rewards to the `reward_token_destination` account.
-/// 3. Closes reward vault token account.
-/// 3. Packs all changes into account buffers.
-pub(crate) fn process_close_pool_reward(
-    program_id: &Pubkey,
-    position_kind: PositionKind,
-    pool_reward_index: u64,
-    accounts: &[AccountInfo],
-) -> ProgramResult {
-    let params = ClosePoolRewardParams::new(position_kind, pool_reward_index);
-
-    let accounts =
-        ClosePoolRewardAccounts::from_unchecked_iter(program_id, &params, &mut accounts.iter())?;
-
-    // 1.
-
-    let unallocated_rewards = todo!("accounts.reserve.close_pool_reward(..)");
-
-    // 2.
-
-    spl_token_transfer(TokenTransferParams {
-        source: accounts.reward_token_vault_info.clone(),
-        destination: accounts.reward_token_destination_info.clone(),
-        amount: unallocated_rewards,
-        authority: accounts.reward_authority_info.clone(),
-        authority_signer_seeds: &reward_vault_authority_seeds(
-            accounts.lending_market_info.key,
-            accounts.reserve_info.key,
-            accounts.reward_mint_info.key,
-        ),
-        token_program: accounts.token_program_info.clone(),
-    })?;
-
-    // 3.
-
-    spl_token_close_account(TokenCloseAccountParams {
-        account: accounts.reward_token_vault_info.clone(),
-        destination: accounts.lending_market_owner_info.clone(),
-        authority: accounts.reward_authority_info.clone(),
-        authority_signer_seeds: &reward_vault_authority_seeds(
-            accounts.lending_market_info.key,
-            accounts.reserve_info.key,
-            accounts.reward_mint_info.key,
-        ),
-        token_program: accounts.token_program_info.clone(),
-    })?;
-
-    // 4.
-    Reserve::pack(
-        *accounts.reserve,
-        &mut accounts.reserve_info.data.borrow_mut(),
-    )?;
-
-    Ok(())
-}
-
-/// Temporary ix to upgrade a reserve to LM feature added in @v2.0.2.
-/// Fails if reserve was not sized as @v2.0.2.
-///
-/// Until this ix is called for a [Reserve] account, all other ixs that try to
-/// unpack the [Reserve] will fail due to size mismatch.
-///
-/// # Accounts
-///
-/// See [upgrade_reserve::UpgradeReserveAccounts::from_unchecked_iter] for a list
-/// of accounts and their constraints.
-///
-/// # Effects
-///
-/// 1. Takes payer's lamports and pays for the rent increase.
-/// 2. Reallocates the reserve account to the latest size.
-/// 3. Repacks the reserve account.
-pub(crate) fn upgrade_reserve(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let accounts = UpgradeReserveAccounts::from_unchecked_iter(program_id, &mut accounts.iter())?;
-
-    //
-    // 1.
-    //
-
-    let current_rent = accounts.reserve_info.lamports();
-    let new_rent = Rent::get()?.minimum_balance(Reserve::LEN);
-
-    if let Some(extra_rent) = new_rent.checked_sub(current_rent) {
-        // some reserves have more rent than necessary, let's not assume that
-        // the payer always needs to add more rent
-
-        invoke(
-            &system_instruction::transfer(
-                accounts.payer.key,
-                accounts.reserve_info.key,
-                extra_rent,
-            ),
-            &[
-                accounts.payer.clone(),
-                accounts.reserve_info.clone(),
-                accounts.system_program.clone(),
-            ],
-        )?;
-    }
-
-    //
-    // 2.
-    //
-
-    // From the [AccountInfo::realloc] docs:
-    //
-    // > Memory used to grow is already zero-initialized upon program entrypoint
-    // > and re-zeroing it wastes compute units. If within the same call a program
-    // > reallocs from larger to smaller and back to larger again the new space
-    // > could contain stale data. Pass true for zero_init in this case,
-    // > otherwise compute units will be wasted re-zero-initializing.
-    let zero_init = false;
-    accounts.reserve_info.realloc(Reserve::LEN, zero_init)?;
-
-    //
-    // 3.
-    //
-
-    // we upgrade discriminator as we've checked that the account is indeed
-    // a reserve account in [UpgradeReserveAccounts::from_unchecked_iter]
-    let mut data = accounts.reserve_info.data.borrow_mut();
-    data[0] = AccountDiscriminator::Reserve as u8;
-    // Now the reserve can unpack fine and doesn't have to worry about
-    // migrations.
-    // Instead it returns an error on an invalid discriminator.
-    // This way a reserve cannot be mistaken for an obligation.
-    let reserve = Reserve::unpack(&data)?;
-    Reserve::pack(reserve, &mut data)?;
-
-    Ok(())
-}
 
 /// Unpacks a spl_token [TokenAccount].
 fn unpack_token_account(data: &[u8]) -> Result<TokenAccount, LendingError> {
@@ -303,6 +39,8 @@ fn unpack_token_account(data: &[u8]) -> Result<TokenAccount, LendingError> {
 }
 
 /// Derives the reward vault authority PDA address.
+///
+/// TODO: Accept a bump seed to avoid recalculating it.
 fn reward_vault_authority(
     program_id: &Pubkey,
     lending_market_key: &Pubkey,
@@ -328,479 +66,11 @@ fn reward_vault_authority_seeds<'keys>(
     ]
 }
 
-mod add_pool_reward {
-    use solend_sdk::state::MIN_REWARD_PERIOD_SECS;
-
-    use super::*;
-
-    /// Use [Self::new] to validate the parameters.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub(super) struct AddPoolRewardParams {
-        pub(super) position_kind: PositionKind,
-        /// At least the current timestamp.
-        pub(super) start_time_secs: u64,
-        /// Larger than [MIN_REWARD_PERIOD_SECS].
-        pub(super) duration_secs: u32,
-        /// Larger than zero.
-        pub(super) reward_token_amount: u64,
-
-        _priv: (),
-    }
-
-    /// Use [Self::from_unchecked_iter] to validate the accounts except for
-    /// * `reward_token_vault_info`
-    /// * `rent_info`
-    pub(super) struct AddPoolRewardAccounts<'a, 'info> {
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        /// ✅ belongs to `lending_market_info`
-        pub(super) reserve_info: &'a AccountInfo<'info>,
-        pub(super) reward_mint_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to the token program
-        /// ✅ owned by `lending_market_owner_info`
-        /// ✅ has enough tokens
-        /// ✅ matches `reward_mint_info`
-        pub(super) reward_token_source_info: &'a AccountInfo<'info>,
-        /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
-        pub(super) reward_authority_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to the token program
-        /// ✅ has no data
-        /// ❓ we don't yet know whether it's rent exempt
-        pub(super) reward_token_vault_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        pub(super) lending_market_info: &'a AccountInfo<'info>,
-        /// ✅ is a signer
-        /// ✅ matches `lending_market_info`
-        /// TBD: do we want to create another signer authority to be able to
-        /// delegate reward management to a softer multisig?
-        pub(super) lending_market_owner_info: &'a AccountInfo<'info>,
-        /// ❓ we don't yet whether this is rent info
-        pub(super) rent_info: &'a AccountInfo<'info>,
-        /// ✅ matches `lending_market_info`
-        pub(super) token_program_info: &'a AccountInfo<'info>,
-
-        pub(super) reserve: Box<Reserve>,
-
-        _priv: (),
-    }
-
-    impl AddPoolRewardParams {
-        pub(super) fn new(
-            position_kind: PositionKind,
-            start_time_secs: u64,
-            end_time_secs: u64,
-            reward_token_amount: u64,
-        ) -> Result<Self, ProgramError> {
-            let clock = &Clock::get()?;
-
-            let start_time_secs = start_time_secs.max(clock.unix_timestamp as u64);
-
-            if start_time_secs <= end_time_secs {
-                msg!("Pool reward must end after it starts");
-                return Err(LendingError::MathOverflow.into());
-            }
-
-            let duration_secs: u32 = {
-                // SAFETY: just checked that start time is strictly smaller
-                let d = end_time_secs - start_time_secs;
-                d.try_into().map_err(|_| {
-                    msg!("Pool reward duration is too long");
-                    LendingError::MathOverflow
-                })?
-            };
-            if MIN_REWARD_PERIOD_SECS > duration_secs as u64 {
-                msg!("Pool reward duration must be at least {MIN_REWARD_PERIOD_SECS} secs");
-                return Err(LendingError::PoolRewardPeriodTooShort.into());
-            }
-
-            if reward_token_amount == 0 {
-                msg!("Pool reward amount must be greater than zero");
-                return Err(LendingError::InvalidAmount.into());
-            }
-
-            Ok(Self {
-                position_kind,
-                start_time_secs,
-                duration_secs,
-                reward_token_amount,
-
-                _priv: (),
-            })
-        }
-    }
-
-    impl<'a, 'info> AddPoolRewardAccounts<'a, 'info> {
-        pub(super) fn from_unchecked_iter(
-            program_id: &Pubkey,
-            params: &AddPoolRewardParams,
-            iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
-        ) -> Result<AddPoolRewardAccounts<'a, 'info>, ProgramError> {
-            let reserve_info = next_account_info(iter)?;
-            let reward_mint_info = next_account_info(iter)?;
-            let reward_token_source_info = next_account_info(iter)?;
-            let reward_authority_info = next_account_info(iter)?;
-            let reward_token_vault_info = next_account_info(iter)?;
-            let lending_market_info = next_account_info(iter)?;
-            let lending_market_owner_info = next_account_info(iter)?;
-            let rent_info = next_account_info(iter)?;
-            let token_program_info = next_account_info(iter)?;
-
-            let reserve = check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve(
-                program_id,
-                reserve_info,
-                reward_mint_info,
-                reward_authority_info,
-                lending_market_info,
-                lending_market_owner_info,
-                token_program_info,
-            )?;
-
-            if reward_token_source_info.owner != token_program_info.key {
-                msg!("Reward token source provided must be owned by the token program");
-                return Err(LendingError::InvalidTokenOwner.into());
-            }
-            let reward_token_source =
-                unpack_token_account(&reward_token_source_info.data.borrow())?;
-            if reward_token_source.owner != *lending_market_owner_info.key {
-                msg!("Reward token source owner does not match the lending market owner provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-            if reward_token_source.amount >= params.reward_token_amount {
-                msg!("Reward token source is empty");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-            if reward_token_source.mint != *reward_mint_info.key {
-                msg!("Reward token source mint does not match the reward mint provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            if reward_token_vault_info.owner != token_program_info.key {
-                msg!("Reward token vault provided must be owned by the token program");
-                return Err(LendingError::InvalidTokenOwner.into());
-            }
-            if !reward_token_vault_info.data.borrow().is_empty() {
-                msg!("Reward token vault provided must be empty");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            Ok(Self {
-                reserve_info,
-                reward_mint_info,
-                reward_token_source_info,
-                reward_authority_info,
-                reward_token_vault_info,
-                lending_market_info,
-                lending_market_owner_info,
-                rent_info,
-                token_program_info,
-
-                reserve,
-
-                _priv: (),
-            })
-        }
-    }
-}
-
-mod cancel_pool_reward {
-    use super::*;
-
-    pub(super) struct CancelPoolRewardParams {
-        position_kind: PositionKind,
-        pool_reward_index: u64,
-
-        _priv: (),
-    }
-
-    /// Use [Self::from_unchecked_iter] to validate the accounts.
-    pub(super) struct CancelPoolRewardAccounts<'a, 'info> {
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        /// ✅ belongs to `lending_market_info`
-        pub(super) reserve_info: &'a AccountInfo<'info>,
-        pub(super) reward_mint_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to the token program
-        /// ✅ owned by `lending_market_owner_info`
-        /// ✅ matches `reward_mint_info`
-        pub(super) reward_token_destination_info: &'a AccountInfo<'info>,
-        /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
-        pub(super) reward_authority_info: &'a AccountInfo<'info>,
-        /// ✅ matches reward vault pubkey stored in the [Reserve]
-        pub(super) reward_token_vault_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        pub(super) lending_market_info: &'a AccountInfo<'info>,
-        /// ✅ is a signer
-        /// ✅ matches `lending_market_info`
-        pub(super) lending_market_owner_info: &'a AccountInfo<'info>,
-        /// ✅ matches `lending_market_info`
-        pub(super) token_program_info: &'a AccountInfo<'info>,
-
-        pub(super) reserve: Box<Reserve>,
-
-        _priv: (),
-    }
-
-    impl<'a, 'info> CancelPoolRewardAccounts<'a, 'info> {
-        pub(super) fn from_unchecked_iter(
-            program_id: &Pubkey,
-            params: &CancelPoolRewardParams,
-            iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
-        ) -> Result<CancelPoolRewardAccounts<'a, 'info>, ProgramError> {
-            let reserve_info = next_account_info(iter)?;
-            let reward_mint_info = next_account_info(iter)?;
-            let reward_token_destination_info = next_account_info(iter)?;
-            let reward_authority_info = next_account_info(iter)?;
-            let reward_token_vault_info = next_account_info(iter)?;
-            let lending_market_info = next_account_info(iter)?;
-            let lending_market_owner_info = next_account_info(iter)?;
-            let token_program_info = next_account_info(iter)?;
-
-            let reserve = check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve(
-                program_id,
-                reserve_info,
-                reward_mint_info,
-                reward_authority_info,
-                lending_market_info,
-                lending_market_owner_info,
-                token_program_info,
-            )?;
-
-            todo!("Check that reward_token_vault_info matches reward vault pubkey stored in [Reserve]");
-
-            if reward_token_destination_info.owner != token_program_info.key {
-                msg!("Reward token destination provided must be owned by the token program");
-                return Err(LendingError::InvalidTokenOwner.into());
-            }
-            let reward_token_destination =
-                unpack_token_account(&reward_token_destination_info.data.borrow())?;
-            if reward_token_destination.owner != *lending_market_owner_info.key {
-                // TBD: superfluous check?
-                msg!("Reward token destination owner does not match the lending market owner provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-            if reward_token_destination.mint != *reward_mint_info.key {
-                msg!("Reward token destination mint does not match the reward mint provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            Ok(Self {
-                _priv: (),
-
-                reserve_info,
-                reward_mint_info,
-                reward_token_destination_info,
-                reward_authority_info,
-                reward_token_vault_info,
-                lending_market_info,
-                lending_market_owner_info,
-                token_program_info,
-
-                reserve,
-            })
-        }
-    }
-
-    impl CancelPoolRewardParams {
-        pub(super) fn new(position_kind: PositionKind, pool_reward_index: u64) -> Self {
-            Self {
-                position_kind,
-                pool_reward_index,
-
-                _priv: (),
-            }
-        }
-    }
-}
-
-mod close_pool_reward {
-    use super::*;
-
-    pub(super) struct ClosePoolRewardParams {
-        position_kind: PositionKind,
-        pool_reward_index: u64,
-
-        _priv: (),
-    }
-
-    /// Use [Self::from_unchecked_iter] to validate the accounts.
-    pub(super) struct ClosePoolRewardAccounts<'a, 'info> {
-        _priv: (),
-
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        /// ✅ belongs to `lending_market_info`
-        pub(super) reserve_info: &'a AccountInfo<'info>,
-        pub(super) reward_mint_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to the token program
-        /// ✅ owned by `lending_market_owner_info`
-        /// ✅ matches `reward_mint_info`
-        pub(super) reward_token_destination_info: &'a AccountInfo<'info>,
-        /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
-        pub(super) reward_authority_info: &'a AccountInfo<'info>,
-        /// ✅ matches reward vault pubkey stored in the [Reserve]
-        pub(super) reward_token_vault_info: &'a AccountInfo<'info>,
-        /// ✅ belongs to this program
-        /// ✅ unpacks
-        pub(super) lending_market_info: &'a AccountInfo<'info>,
-        /// ✅ is a signer
-        /// ✅ matches `lending_market_info`
-        pub(super) lending_market_owner_info: &'a AccountInfo<'info>,
-        /// ✅ matches `lending_market_info`
-        pub(super) token_program_info: &'a AccountInfo<'info>,
-
-        pub(super) reserve: Box<Reserve>,
-    }
-
-    impl<'a, 'info> ClosePoolRewardAccounts<'a, 'info> {
-        pub(super) fn from_unchecked_iter(
-            program_id: &Pubkey,
-            params: &ClosePoolRewardParams,
-            iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
-        ) -> Result<ClosePoolRewardAccounts<'a, 'info>, ProgramError> {
-            let reserve_info = next_account_info(iter)?;
-            let reward_mint_info = next_account_info(iter)?;
-            let reward_token_destination_info = next_account_info(iter)?;
-            let reward_authority_info = next_account_info(iter)?;
-            let reward_token_vault_info = next_account_info(iter)?;
-            let lending_market_info = next_account_info(iter)?;
-            let lending_market_owner_info = next_account_info(iter)?;
-            let token_program_info = next_account_info(iter)?;
-
-            let reserve = check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve(
-                program_id,
-                reserve_info,
-                reward_mint_info,
-                reward_authority_info,
-                lending_market_info,
-                lending_market_owner_info,
-                token_program_info,
-            )?;
-
-            todo!("Check that reward_token_vault_info matches reward vault pubkey stored in [Reserve]");
-
-            if reward_token_destination_info.owner != token_program_info.key {
-                msg!("Reward token destination provided must be owned by the token program");
-                return Err(LendingError::InvalidTokenOwner.into());
-            }
-            let reward_token_destination =
-                unpack_token_account(&reward_token_destination_info.data.borrow())?;
-            if reward_token_destination.owner != *lending_market_owner_info.key {
-                // TBD: superfluous check?
-                msg!("Reward token destination owner does not match the lending market owner provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-            if reward_token_destination.mint != *reward_mint_info.key {
-                msg!("Reward token destination mint does not match the reward mint provided");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            Ok(Self {
-                reserve_info,
-                reward_mint_info,
-                reward_token_destination_info,
-                reward_authority_info,
-                reward_token_vault_info,
-                lending_market_info,
-                lending_market_owner_info,
-                token_program_info,
-
-                reserve,
-
-                _priv: (),
-            })
-        }
-    }
-
-    impl ClosePoolRewardParams {
-        pub(super) fn new(position_kind: PositionKind, pool_reward_index: u64) -> Self {
-            Self {
-                position_kind,
-                pool_reward_index,
-
-                _priv: (),
-            }
-        }
-    }
-}
-
-mod upgrade_reserve {
-    use solend_sdk::state::RESERVE_LEN_V2_0_2;
-
-    use super::*;
-
-    pub(super) struct UpgradeReserveAccounts<'a, 'info> {
-        /// Reserve sized as v2.0.2.
-        ///
-        /// ✅ belongs to this program
-        /// ✅ is sized [RESERVE_LEN_V2_0_2], ie. for sure [Reserve] account
-        pub(super) reserve_info: &'a AccountInfo<'info>,
-        /// The pool fella who pays for this.
-        ///
-        /// ✅ is a signer
-        pub(super) payer: &'a AccountInfo<'info>,
-        /// The system program.
-        ///
-        /// ✅ is the system program
-        pub(super) system_program: &'a AccountInfo<'info>,
-
-        _priv: (),
-    }
-
-    impl<'a, 'info> UpgradeReserveAccounts<'a, 'info> {
-        pub(super) fn from_unchecked_iter(
-            program_id: &Pubkey,
-            iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
-        ) -> Result<UpgradeReserveAccounts<'a, 'info>, ProgramError> {
-            let reserve_info = next_account_info(iter)?;
-            let payer = next_account_info(iter)?;
-            let system_program = next_account_info(iter)?;
-
-            if !payer.is_signer {
-                msg!("Payer provided must be a signer");
-                return Err(LendingError::InvalidSigner.into());
-            }
-
-            if reserve_info.owner != program_id {
-                msg!("Reserve provided must be owned by the lending program");
-                return Err(LendingError::InvalidAccountOwner.into());
-            }
-
-            if reserve_info.data_len() != RESERVE_LEN_V2_0_2 {
-                msg!("Reserve provided must be sized as v2.0.2");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            if system_program.key != &solana_program::system_program::id() {
-                msg!("System program provided must be the system program");
-                return Err(LendingError::InvalidAccountInput.into());
-            }
-
-            Ok(Self {
-                payer,
-                reserve_info,
-                system_program,
-                _priv: (),
-            })
-        }
-    }
-}
-
-/// Common checks within the admin ixs are:
+/// Does all the checks of [check_and_unpack_pool_reward_accounts] and additionally:
 ///
-/// * ✅ `reserve_info` belongs to this program
-/// * ✅ `reserve_info` unpacks
-/// * ✅ `reserve_info` belongs to `lending_market_info`
-/// * ✅ `reward_authority_info` is seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
-/// * ✅ `lending_market_info` belongs to this program
-/// * ✅ `lending_market_info` unpacks
 /// * ✅ `lending_market_owner_info` is a signer
 /// * ✅ `lending_market_owner_info` matches `lending_market_info`
-/// * ✅ `token_program_info` matches `lending_market_info`
-///
-/// To avoid unpacking reserve twice we return it.
-fn check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve<'info>(
+fn check_and_unpack_pool_reward_accounts_for_admin_ixs<'info>(
     program_id: &Pubkey,
     reserve_info: &AccountInfo<'info>,
     reward_mint_info: &AccountInfo<'info>,
@@ -808,7 +78,46 @@ fn check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve<'info>(
     lending_market_info: &AccountInfo<'info>,
     lending_market_owner_info: &AccountInfo<'info>,
     token_program_info: &AccountInfo<'info>,
-) -> Result<Box<Reserve>, ProgramError> {
+) -> Result<(LendingMarket, Box<Reserve>), ProgramError> {
+    let (lending_market, reserve) = check_and_unpack_pool_reward_accounts(
+        program_id,
+        reserve_info,
+        reward_mint_info,
+        reward_authority_info,
+        lending_market_info,
+        token_program_info,
+    )?;
+
+    if lending_market.owner != *lending_market_owner_info.key {
+        msg!("Lending market owner does not match the lending market owner provided");
+        return Err(LendingError::InvalidMarketOwner.into());
+    }
+    if !lending_market_owner_info.is_signer {
+        msg!("Lending market owner provided must be a signer");
+        return Err(LendingError::InvalidSigner.into());
+    }
+
+    Ok((lending_market, reserve))
+}
+
+/// Checks that:
+///
+/// * ✅ `reserve_info` belongs to this program
+/// * ✅ `reserve_info` unpacks
+/// * ✅ `reserve_info` belongs to `lending_market_info`
+/// * ✅ `reward_authority_info` is seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
+/// * ✅ `lending_market_info` belongs to this program
+/// * ✅ `lending_market_info` unpacks
+/// * ✅ `token_program_info` matches `lending_market_info`
+/// * ✅ `reward_mint_info` belongs to the token program
+fn check_and_unpack_pool_reward_accounts<'info>(
+    program_id: &Pubkey,
+    reserve_info: &AccountInfo<'info>,
+    reward_mint_info: &AccountInfo<'info>,
+    reward_authority_info: &AccountInfo<'info>,
+    lending_market_info: &AccountInfo<'info>,
+    token_program_info: &AccountInfo<'info>,
+) -> Result<(LendingMarket, Box<Reserve>), ProgramError> {
     if reserve_info.owner != program_id {
         msg!("Reserve provided is not owned by the lending program");
         return Err(LendingError::InvalidAccountOwner.into());
@@ -831,13 +140,9 @@ fn check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve<'info>(
         return Err(LendingError::InvalidTokenProgram.into());
     }
 
-    if lending_market.owner != *lending_market_owner_info.key {
-        msg!("Lending market owner does not match the lending market owner provided");
-        return Err(LendingError::InvalidMarketOwner.into());
-    }
-    if !lending_market_owner_info.is_signer {
-        msg!("Lending market owner provided must be a signer");
-        return Err(LendingError::InvalidSigner.into());
+    if reward_mint_info.owner != token_program_info.key {
+        msg!("Reward mint provided must be owned by the token program");
+        return Err(LendingError::InvalidTokenOwner.into());
     }
 
     let (expected_reward_vault_authority, _bump_seed) = reward_vault_authority(
@@ -851,5 +156,5 @@ fn check_pool_reward_accounts_for_admin_ixs_and_unpack_reserve<'info>(
         return Err(LendingError::InvalidAccountInput.into());
     }
 
-    Ok(reserve)
+    Ok((lending_market, reserve))
 }

--- a/token-lending/program/src/processor/liquidity_mining/add_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/add_pool_reward.rs
@@ -1,3 +1,7 @@
+//! Adds a new pool reward to a reserve.
+//!
+//! Each pool reward has a unique vault that holds the reward tokens.
+
 use crate::processor::{
     assert_rent_exempt, spl_token_init_account, spl_token_transfer, TokenInitializeAccountParams,
     TokenTransferParams,

--- a/token-lending/program/src/processor/liquidity_mining/add_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/add_pool_reward.rs
@@ -1,0 +1,262 @@
+use crate::processor::{
+    assert_rent_exempt, spl_token_init_account, spl_token_transfer, TokenInitializeAccountParams,
+    TokenTransferParams,
+};
+use solana_program::program_pack::Pack;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    clock::Clock,
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+use solend_sdk::state::MIN_REWARD_PERIOD_SECS;
+use solend_sdk::{
+    error::LendingError,
+    state::{PositionKind, Reserve},
+};
+use std::convert::TryInto;
+
+use super::{check_and_unpack_pool_reward_accounts_for_admin_ixs, unpack_token_account};
+
+/// Use [Self::new] to validate the parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AddPoolRewardParams {
+    position_kind: PositionKind,
+    /// At least the current timestamp.
+    start_time_secs: u64,
+    /// Larger than [MIN_REWARD_PERIOD_SECS].
+    duration_secs: u32,
+    /// Larger than zero.
+    reward_token_amount: u64,
+}
+
+/// Use [Self::from_unchecked_iter] to validate the accounts except for
+/// * `reward_token_vault_info`
+/// * `rent_info`
+struct AddPoolRewardAccounts<'a, 'info> {
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    /// ✅ belongs to `lending_market_info`
+    /// ✅ is writable
+    reserve_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    reward_mint_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ owned by `lending_market_owner_info`
+    /// ✅ has enough tokens
+    /// ✅ matches `reward_mint_info`
+    /// ✅ is writable
+    reward_token_source_info: &'a AccountInfo<'info>,
+    /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
+    reward_authority_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ has no data
+    /// ✅ is writable
+    /// ❓ we don't yet know whether it's rent exempt
+    reward_token_vault_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    _lending_market_info: &'a AccountInfo<'info>,
+    /// ✅ is a signer
+    /// ✅ matches `lending_market_info`
+    /// TBD: do we want to create another signer authority to be able to
+    /// delegate reward management to a softer multisig?
+    lending_market_owner_info: &'a AccountInfo<'info>,
+    /// ❓ we don't yet whether this is rent info
+    rent_info: &'a AccountInfo<'info>,
+    /// ✅ matches `lending_market_info`
+    token_program_info: &'a AccountInfo<'info>,
+
+    reserve: Box<Reserve>,
+}
+
+/// # Effects
+///
+/// 1. Initializes a new reward vault account and transfers
+///    `reward_token_amount` tokens from the `reward_token_source` account to
+///     the new reward vault account.
+/// 2. Finds an empty slot in the [Reserve]'s LM reward vector and adds it there.
+/// 3. Packs all changes into account buffers.
+pub(crate) fn process(
+    program_id: &Pubkey,
+    position_kind: PositionKind,
+    start_time_secs: u64,
+    end_time_secs: u64,
+    reward_token_amount: u64,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let params = AddPoolRewardParams::new(
+        position_kind,
+        start_time_secs,
+        end_time_secs,
+        reward_token_amount,
+    )?;
+
+    let accounts =
+        AddPoolRewardAccounts::from_unchecked_iter(program_id, &params, &mut accounts.iter())?;
+
+    // 1.
+
+    spl_token_init_account(TokenInitializeAccountParams {
+        account: accounts.reward_token_vault_info.clone(),
+        mint: accounts.reward_mint_info.clone(),
+        owner: accounts.reward_authority_info.clone(),
+        rent: accounts.rent_info.clone(),
+        token_program: accounts.token_program_info.clone(),
+    })?;
+    let rent = &Rent::from_account_info(accounts.rent_info)?;
+    assert_rent_exempt(rent, accounts.reward_token_vault_info)?;
+
+    spl_token_transfer(TokenTransferParams {
+        source: accounts.reward_token_source_info.clone(),
+        destination: accounts.reward_token_vault_info.clone(),
+        amount: params.reward_token_amount,
+        authority: accounts.lending_market_owner_info.clone(),
+        authority_signer_seeds: &[],
+        token_program: accounts.token_program_info.clone(),
+    })?;
+
+    // 2.
+
+    // TODO: accounts.reserve.add_pool_reward(..)
+
+    // 3.
+
+    Reserve::pack(
+        *accounts.reserve,
+        &mut accounts.reserve_info.data.borrow_mut(),
+    )?;
+
+    Ok(())
+}
+
+impl AddPoolRewardParams {
+    fn new(
+        position_kind: PositionKind,
+        start_time_secs: u64,
+        end_time_secs: u64,
+        reward_token_amount: u64,
+    ) -> Result<Self, ProgramError> {
+        let clock = &Clock::get()?;
+
+        let start_time_secs = start_time_secs.max(clock.unix_timestamp as u64);
+
+        if start_time_secs <= end_time_secs {
+            msg!("Pool reward must end after it starts");
+            return Err(LendingError::MathOverflow.into());
+        }
+
+        let duration_secs: u32 = {
+            // SAFETY: just checked that start time is strictly smaller
+            let d = end_time_secs - start_time_secs;
+            d.try_into().map_err(|_| {
+                msg!("Pool reward duration is too long");
+                LendingError::MathOverflow
+            })?
+        };
+        if MIN_REWARD_PERIOD_SECS > duration_secs as u64 {
+            msg!("Pool reward duration must be at least {MIN_REWARD_PERIOD_SECS} secs");
+            return Err(LendingError::PoolRewardPeriodTooShort.into());
+        }
+
+        if reward_token_amount == 0 {
+            msg!("Pool reward amount must be greater than zero");
+            return Err(LendingError::InvalidAmount.into());
+        }
+
+        Ok(Self {
+            position_kind,
+            start_time_secs,
+            duration_secs,
+            reward_token_amount,
+        })
+    }
+}
+
+impl<'a, 'info> AddPoolRewardAccounts<'a, 'info> {
+    fn from_unchecked_iter(
+        program_id: &Pubkey,
+        params: &AddPoolRewardParams,
+        iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
+    ) -> Result<AddPoolRewardAccounts<'a, 'info>, ProgramError> {
+        let reserve_info = next_account_info(iter)?;
+        let reward_mint_info = next_account_info(iter)?;
+        let reward_token_source_info = next_account_info(iter)?;
+        let reward_authority_info = next_account_info(iter)?;
+        let reward_token_vault_info = next_account_info(iter)?;
+        let lending_market_info = next_account_info(iter)?;
+        let lending_market_owner_info = next_account_info(iter)?;
+        let rent_info = next_account_info(iter)?;
+        let token_program_info = next_account_info(iter)?;
+
+        let (_, reserve) = check_and_unpack_pool_reward_accounts_for_admin_ixs(
+            program_id,
+            reserve_info,
+            reward_mint_info,
+            reward_authority_info,
+            lending_market_info,
+            lending_market_owner_info,
+            token_program_info,
+        )?;
+
+        if reward_token_source_info.owner != token_program_info.key {
+            msg!("Reward token source provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
+        }
+        let reward_token_source = unpack_token_account(&reward_token_source_info.data.borrow())?;
+        if reward_token_source.owner != *lending_market_owner_info.key {
+            msg!("Reward token source owner does not match the lending market owner provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+        if reward_token_source.amount >= params.reward_token_amount {
+            msg!("Reward token source is empty");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+        if reward_token_source.mint != *reward_mint_info.key {
+            msg!("Reward token source mint does not match the reward mint provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        if reward_token_vault_info.owner != token_program_info.key {
+            msg!("Reward token vault provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
+        }
+        if !reward_token_vault_info.data.borrow().is_empty() {
+            msg!("Reward token vault provided must be empty");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        // check that accounts that should be writable are writable
+
+        if !reward_token_vault_info.is_writable {
+            msg!("Reward token vault provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reserve_info.is_writable {
+            msg!("Reserve provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reward_token_source_info.is_writable {
+            msg!("Reward token source provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            reserve_info,
+            reward_mint_info,
+            reward_token_source_info,
+            reward_authority_info,
+            reward_token_vault_info,
+            _lending_market_info: lending_market_info,
+            lending_market_owner_info,
+            rent_info,
+            token_program_info,
+
+            reserve,
+        })
+    }
+}

--- a/token-lending/program/src/processor/liquidity_mining/cancel_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/cancel_pool_reward.rs
@@ -1,0 +1,168 @@
+use crate::processor::liquidity_mining::{
+    check_and_unpack_pool_reward_accounts_for_admin_ixs, unpack_token_account,
+};
+use crate::processor::{spl_token_transfer, TokenTransferParams};
+use solana_program::program_pack::Pack;
+use solana_program::sysvar::Sysvar;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    clock::Clock,
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+use solend_sdk::{
+    error::LendingError,
+    state::{PositionKind, Reserve},
+};
+
+use super::reward_vault_authority_seeds;
+
+/// Use [Self::from_unchecked_iter] to validate the accounts.
+struct CancelPoolRewardAccounts<'a, 'info> {
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    /// ✅ belongs to `lending_market_info`
+    /// ✅ is writable
+    reserve_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    reward_mint_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ matches `reward_mint_info`
+    /// ✅ is writable
+    reward_token_destination_info: &'a AccountInfo<'info>,
+    /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
+    reward_authority_info: &'a AccountInfo<'info>,
+    /// ❓ we don't know whether it matches the reward vault pubkey stored in [Reserve]
+    /// ✅ is writable
+    reward_token_vault_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    lending_market_info: &'a AccountInfo<'info>,
+    /// ✅ is a signer
+    /// ✅ matches `lending_market_info`
+    _lending_market_owner_info: &'a AccountInfo<'info>,
+    /// ✅ matches `lending_market_info`
+    token_program_info: &'a AccountInfo<'info>,
+
+    reserve: Box<Reserve>,
+}
+
+/// # Effects
+///
+/// 1. Cancels any further reward emission, effectively setting end time to now.
+/// 2. Transfers any unallocated rewards to the `reward_token_destination` account.
+/// 3. Packs all changes into account buffers.
+pub(crate) fn process(
+    program_id: &Pubkey,
+    position_kind: PositionKind,
+    pool_reward_index: usize,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let mut accounts =
+        CancelPoolRewardAccounts::from_unchecked_iter(program_id, &mut accounts.iter())?;
+
+    // 1.
+
+    let pool_reward_manager = match position_kind {
+        PositionKind::Borrow => &mut accounts.reserve.borrows_pool_reward_manager,
+        PositionKind::Deposit => &mut accounts.reserve.deposits_pool_reward_manager,
+    };
+    let (expected_vault, unallocated_rewards) =
+        pool_reward_manager.cancel_pool_reward(pool_reward_index, &Clock::get()?)?;
+
+    if expected_vault != *accounts.reward_token_vault_info.key {
+        msg!("Reward vault provided does not match the reward vault pubkey stored in [Reserve]");
+        return Err(LendingError::InvalidAccountInput.into());
+    }
+
+    // 2.
+
+    spl_token_transfer(TokenTransferParams {
+        source: accounts.reward_token_vault_info.clone(),
+        destination: accounts.reward_token_destination_info.clone(),
+        amount: unallocated_rewards,
+        authority: accounts.reward_authority_info.clone(),
+        authority_signer_seeds: &reward_vault_authority_seeds(
+            accounts.lending_market_info.key,
+            accounts.reserve_info.key,
+            accounts.reward_mint_info.key,
+        ),
+        token_program: accounts.token_program_info.clone(),
+    })?;
+
+    // 3.
+
+    Reserve::pack(
+        *accounts.reserve,
+        &mut accounts.reserve_info.data.borrow_mut(),
+    )?;
+
+    Ok(())
+}
+
+impl<'a, 'info> CancelPoolRewardAccounts<'a, 'info> {
+    fn from_unchecked_iter(
+        program_id: &Pubkey,
+        iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
+    ) -> Result<CancelPoolRewardAccounts<'a, 'info>, ProgramError> {
+        let reserve_info = next_account_info(iter)?;
+        let reward_mint_info = next_account_info(iter)?;
+        let reward_token_destination_info = next_account_info(iter)?;
+        let reward_authority_info = next_account_info(iter)?;
+        let reward_token_vault_info = next_account_info(iter)?;
+        let lending_market_info = next_account_info(iter)?;
+        let lending_market_owner_info = next_account_info(iter)?;
+        let token_program_info = next_account_info(iter)?;
+
+        let (_, reserve) = check_and_unpack_pool_reward_accounts_for_admin_ixs(
+            program_id,
+            reserve_info,
+            reward_mint_info,
+            reward_authority_info,
+            lending_market_info,
+            lending_market_owner_info,
+            token_program_info,
+        )?;
+
+        if reward_token_destination_info.owner != token_program_info.key {
+            msg!("Reward token destination provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
+        }
+        let reward_token_destination =
+            unpack_token_account(&reward_token_destination_info.data.borrow())?;
+        if reward_token_destination.mint != *reward_mint_info.key {
+            msg!("Reward token destination mint does not match the reward mint provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        // check that accounts that should be writable are writable
+
+        if !reward_token_vault_info.is_writable {
+            msg!("Reward token vault provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reserve_info.is_writable {
+            msg!("Reserve provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reward_token_destination_info.is_writable {
+            msg!("Reward token destination provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            reserve_info,
+            reward_mint_info,
+            reward_token_destination_info,
+            reward_authority_info,
+            reward_token_vault_info,
+            lending_market_info,
+            _lending_market_owner_info: lending_market_owner_info,
+            token_program_info,
+
+            reserve,
+        })
+    }
+}

--- a/token-lending/program/src/processor/liquidity_mining/claim_user_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/claim_user_reward.rs
@@ -1,0 +1,235 @@
+use crate::processor::{spl_token_transfer, TokenTransferParams};
+use solana_program::program_pack::Pack;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    clock::Clock,
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvar::Sysvar,
+};
+use solend_sdk::state::{CreatingNewUserRewardManager, Obligation};
+use solend_sdk::{
+    error::LendingError,
+    state::{PositionKind, Reserve},
+};
+
+use super::{
+    check_and_unpack_pool_reward_accounts, reward_vault_authority_seeds, unpack_token_account,
+};
+
+/// Use [Self::from_unchecked_iter] to validate the accounts.
+struct ClaimUserReward<'a, 'info> {
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    /// ✅ matches `lending_market_info`
+    /// ✅ is writable
+    obligation_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ is writable
+    /// ✅ matches `reward_mint_info`
+    /// ✅ owned by the obligation owner
+    obligation_owner_token_account_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    /// ✅ belongs to `lending_market_info`
+    /// ✅ is writable
+    reserve_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    reward_mint_info: &'a AccountInfo<'info>,
+    /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
+    reward_authority_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ unpacks to a [TokenAccount]
+    /// ✅ owned by `reward_authority_info`
+    /// ✅ matches `reward_mint_info`
+    /// ✅ is writable
+    reward_token_vault_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    lending_market_info: &'a AccountInfo<'info>,
+    /// ✅ matches `lending_market_info`
+    token_program_info: &'a AccountInfo<'info>,
+
+    obligation: Box<Obligation>,
+    reserve: Box<Reserve>,
+}
+
+/// # Effects
+///
+/// 1. Updates the user reward manager with the pool reward manager and accrues rewards
+/// 2. Withdraws all eligible rewards from [UserRewardManager].
+///    Eligible rewards are those that match the vault and user has earned any.
+/// 3. Transfers the withdrawn rewards to the user's token account.
+/// 4. Packs all changes into account buffers for [Obligation] and [Reserve].
+pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let mut accounts = ClaimUserReward::from_unchecked_iter(program_id, &mut accounts.iter())?;
+
+    // 1.
+
+    let position_kind = accounts
+        .obligation
+        .find_position_kind(*accounts.reserve_info.key)?;
+
+    let Some(user_reward_manager) = accounts
+        .obligation
+        .find_user_reward_manager_mut(*accounts.reserve_info.key)
+    else {
+        // Let's not error if a user has no rewards to claim for this reserve.
+        // Having this ix idempotent makes cranking easier.
+        return Ok(());
+    };
+
+    let pool_reward_manager = match position_kind {
+        PositionKind::Borrow => &mut accounts.reserve.borrows_pool_reward_manager,
+        PositionKind::Deposit => &mut accounts.reserve.deposits_pool_reward_manager,
+    };
+
+    let clock = &Clock::get()?;
+
+    // Syncs the pool reward manager with the user manager and accrues rewards.
+    // If we wanted to optimize CU usage then we could make a dedicated update
+    // function only for claiming rewards to avoid iterating twice over the rewards.
+    user_reward_manager.update(pool_reward_manager, clock, CreatingNewUserRewardManager::No)?;
+
+    // 2.
+
+    let total_reward_amount = user_reward_manager.claim_rewards(
+        pool_reward_manager,
+        *accounts.reward_token_vault_info.key,
+        clock,
+    )?;
+
+    // 3.
+
+    spl_token_transfer(TokenTransferParams {
+        source: accounts.reward_token_vault_info.clone(),
+        destination: accounts.obligation_owner_token_account_info.clone(),
+        amount: total_reward_amount,
+        authority: accounts.reward_authority_info.clone(),
+        authority_signer_seeds: &reward_vault_authority_seeds(
+            accounts.lending_market_info.key,
+            accounts.reserve_info.key,
+            accounts.reward_mint_info.key,
+        ),
+        token_program: accounts.token_program_info.clone(),
+    })?;
+
+    // 4.
+
+    Obligation::pack(
+        *accounts.obligation,
+        &mut accounts.obligation_info.data.borrow_mut(),
+    )?;
+
+    Reserve::pack(
+        *accounts.reserve,
+        &mut accounts.reserve_info.data.borrow_mut(),
+    )?;
+
+    Ok(())
+}
+
+impl<'a, 'info> ClaimUserReward<'a, 'info> {
+    fn from_unchecked_iter(
+        program_id: &Pubkey,
+        iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
+    ) -> Result<ClaimUserReward<'a, 'info>, ProgramError> {
+        let obligation_info = next_account_info(iter)?;
+        let obligation_owner_token_account_info = next_account_info(iter)?;
+        let reserve_info = next_account_info(iter)?;
+        let reward_mint_info = next_account_info(iter)?;
+        let reward_authority_info = next_account_info(iter)?;
+        let reward_token_vault_info = next_account_info(iter)?;
+        let lending_market_info = next_account_info(iter)?;
+        let token_program_info = next_account_info(iter)?;
+
+        let (_, reserve) = check_and_unpack_pool_reward_accounts(
+            program_id,
+            reserve_info,
+            reward_mint_info,
+            reward_authority_info,
+            lending_market_info,
+            token_program_info,
+        )?;
+
+        if obligation_info.owner != program_id {
+            msg!("Obligation provided is not owned by the lending program");
+            return Err(LendingError::InvalidAccountOwner.into());
+        }
+
+        let obligation = Box::new(Obligation::unpack(&obligation_info.data.borrow())?);
+
+        if obligation.lending_market != *lending_market_info.key {
+            msg!("Obligation lending market does not match the lending market provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        if obligation_owner_token_account_info.owner != token_program_info.key {
+            msg!("Obligation owner token account provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
+        }
+        let obligation_owner_token_account =
+            unpack_token_account(&obligation_owner_token_account_info.data.borrow())?;
+
+        if obligation_owner_token_account.owner != obligation.owner {
+            msg!(
+                "Obligation owner token account owner does not match the obligation owner provided"
+            );
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+        if obligation_owner_token_account.mint != *reward_mint_info.key {
+            msg!("Obligation owner token account mint does not match the reward mint provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        if reward_token_vault_info.owner != token_program_info.key {
+            msg!("Reward token vault provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
+        }
+        let reward_token_vault = unpack_token_account(&reward_token_vault_info.data.borrow())?;
+
+        if reward_token_vault.owner != *reward_authority_info.key {
+            msg!("Reward token vault owner does not match the reward authority provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+        if reward_token_vault.mint != *reward_mint_info.key {
+            msg!("Reward token vault mint does not match the reward mint provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        // check that accounts that should be writable are writable
+
+        if !obligation_info.is_writable {
+            msg!("Obligation provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !obligation_owner_token_account_info.is_writable {
+            msg!("Obligation owner token account provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reward_token_vault_info.is_writable {
+            msg!("Reward token vault provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reserve_info.is_writable {
+            msg!("Reserve provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            obligation_info,
+            obligation_owner_token_account_info,
+            reserve_info,
+            reward_mint_info,
+            reward_authority_info,
+            reward_token_vault_info,
+            lending_market_info,
+            token_program_info,
+
+            reserve,
+            obligation,
+        })
+    }
+}

--- a/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
@@ -58,6 +58,7 @@ pub(crate) fn process(
     pool_reward_manager.close_pool_reward(pool_reward_index)?;
 
     // 2.
+
     Reserve::pack(
         *accounts.reserve,
         &mut accounts.reserve_info.data.borrow_mut(),

--- a/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
@@ -1,0 +1,119 @@
+//! Closes a pool reward, making its slot vacant and ready for a new reward.
+//!
+//! Before closing a pool reward that pool reward must first be cancelled
+//! and all rewards must be claimed by the users.
+//!
+//! The claim ix is permission-less and therefore it can be cranked.
+
+use solana_program::program_pack::Pack;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+use solend_sdk::state::LendingMarket;
+use solend_sdk::{
+    error::LendingError,
+    state::{PositionKind, Reserve},
+};
+
+/// Use [Self::from_unchecked_iter] to validate the accounts.
+struct ClosePoolRewardAccounts<'a, 'info> {
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    /// ✅ belongs to `lending_market_info`
+    /// ✅ is writable
+    reserve_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to this program
+    /// ✅ unpacks
+    _lending_market_info: &'a AccountInfo<'info>,
+    /// ✅ is a signer
+    /// ✅ matches `lending_market_info` owner
+    _lending_market_owner_info: &'a AccountInfo<'info>,
+
+    reserve: Box<Reserve>,
+}
+
+/// # Effects
+///
+/// 1. Closes reward in the [Reserve] account if all users have claimed.
+/// 2. Packs all changes into account buffers.
+pub(crate) fn process(
+    program_id: &Pubkey,
+    position_kind: PositionKind,
+    pool_reward_index: usize,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let mut accounts =
+        ClosePoolRewardAccounts::from_unchecked_iter(program_id, &mut accounts.iter())?;
+
+    // 1.
+
+    let pool_reward_manager = match position_kind {
+        PositionKind::Borrow => &mut accounts.reserve.borrows_pool_reward_manager,
+        PositionKind::Deposit => &mut accounts.reserve.deposits_pool_reward_manager,
+    };
+    pool_reward_manager.close_pool_reward(pool_reward_index)?;
+
+    // 2.
+    Reserve::pack(
+        *accounts.reserve,
+        &mut accounts.reserve_info.data.borrow_mut(),
+    )?;
+
+    Ok(())
+}
+
+impl<'a, 'info> ClosePoolRewardAccounts<'a, 'info> {
+    fn from_unchecked_iter(
+        program_id: &Pubkey,
+        iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
+    ) -> Result<ClosePoolRewardAccounts<'a, 'info>, ProgramError> {
+        let reserve_info = next_account_info(iter)?;
+        let lending_market_info = next_account_info(iter)?;
+        let lending_market_owner_info = next_account_info(iter)?;
+
+        if reserve_info.owner != program_id {
+            msg!("Reserve provided is not owned by the lending program");
+            return Err(LendingError::InvalidAccountOwner.into());
+        }
+        let reserve = Box::new(Reserve::unpack(&reserve_info.data.borrow())?);
+
+        if lending_market_info.owner != program_id {
+            msg!("Lending market provided is not owned by the lending program");
+            return Err(LendingError::InvalidAccountOwner.into());
+        }
+        let lending_market = LendingMarket::unpack(&lending_market_info.data.borrow())?;
+
+        if reserve.lending_market != *lending_market_info.key {
+            msg!("Reserve lending market does not match the lending market provided");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        if lending_market.owner != *lending_market_owner_info.key {
+            msg!("Lending market owner does not match the lending market owner provided");
+            return Err(LendingError::InvalidMarketOwner.into());
+        }
+        if !lending_market_owner_info.is_signer {
+            msg!("Lending market owner provided must be a signer");
+            return Err(LendingError::InvalidSigner.into());
+        }
+
+        // check that accounts that should be writable are writable
+
+        if !reserve_info.is_writable {
+            msg!("Reserve provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            reserve_info,
+            _lending_market_info: lending_market_info,
+            _lending_market_owner_info: lending_market_owner_info,
+
+            reserve,
+        })
+    }
+}

--- a/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
+++ b/token-lending/program/src/processor/liquidity_mining/close_pool_reward.rs
@@ -13,10 +13,19 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
 };
-use solend_sdk::state::LendingMarket;
 use solend_sdk::{
     error::LendingError,
     state::{PositionKind, Reserve},
+};
+use spl_token::state::Account as TokenAccount;
+
+use crate::processor::{
+    spl_token_close_account, spl_token_transfer, TokenCloseAccountParams, TokenTransferParams,
+};
+
+use super::{
+    check_and_unpack_pool_reward_accounts_for_admin_ixs, reward_vault_authority_seeds,
+    unpack_token_account,
 };
 
 /// Use [Self::from_unchecked_iter] to validate the accounts.
@@ -26,20 +35,38 @@ struct ClosePoolRewardAccounts<'a, 'info> {
     /// ✅ belongs to `lending_market_info`
     /// ✅ is writable
     reserve_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    reward_mint_info: &'a AccountInfo<'info>,
+    /// ✅ belongs to the token program
+    /// ✅ owned by `lending_market_owner_info`
+    /// ✅ matches `reward_mint_info`
+    /// ✅ is writable
+    reward_token_destination_info: &'a AccountInfo<'info>,
+    /// ✅ seed of `lending_market_info`, `reserve_info`, `reward_mint_info`
+    reward_authority_info: &'a AccountInfo<'info>,
+    /// ❓ we don't know whether it matches vault in the [Reserve]
+    /// ✅ is writable
+    /// ✅ unpacks
+    reward_token_vault_info: &'a AccountInfo<'info>,
     /// ✅ belongs to this program
     /// ✅ unpacks
-    _lending_market_info: &'a AccountInfo<'info>,
+    lending_market_info: &'a AccountInfo<'info>,
     /// ✅ is a signer
-    /// ✅ matches `lending_market_info` owner
-    _lending_market_owner_info: &'a AccountInfo<'info>,
+    /// ✅ matches `lending_market_info`
+    lending_market_owner_info: &'a AccountInfo<'info>,
+    /// ✅ matches `lending_market_info`
+    token_program_info: &'a AccountInfo<'info>,
 
     reserve: Box<Reserve>,
+    reward_token_vault: TokenAccount,
 }
 
 /// # Effects
 ///
 /// 1. Closes reward in the [Reserve] account if all users have claimed.
-/// 2. Packs all changes into account buffers.
+/// 2. Transfers dust to the `reward_token_destination` account.
+/// 3. Closes reward vault token account.
+/// 3. Packs all changes into account buffers.
 pub(crate) fn process(
     program_id: &Pubkey,
     position_kind: PositionKind,
@@ -55,9 +82,42 @@ pub(crate) fn process(
         PositionKind::Borrow => &mut accounts.reserve.borrows_pool_reward_manager,
         PositionKind::Deposit => &mut accounts.reserve.deposits_pool_reward_manager,
     };
-    pool_reward_manager.close_pool_reward(pool_reward_index)?;
+    let expected_vault = pool_reward_manager.close_pool_reward(pool_reward_index)?;
+    if expected_vault != *accounts.reward_token_vault_info.key {
+        msg!("Reward token vault provided does not match the expected vault");
+        return Err(LendingError::InvalidAccountInput.into());
+    }
 
     // 2.
+
+    spl_token_transfer(TokenTransferParams {
+        source: accounts.reward_token_vault_info.clone(),
+        destination: accounts.reward_token_destination_info.clone(),
+        amount: accounts.reward_token_vault.amount,
+        authority: accounts.reward_authority_info.clone(),
+        authority_signer_seeds: &reward_vault_authority_seeds(
+            accounts.lending_market_info.key,
+            accounts.reserve_info.key,
+            accounts.reward_mint_info.key,
+        ),
+        token_program: accounts.token_program_info.clone(),
+    })?;
+
+    // 3.
+
+    spl_token_close_account(TokenCloseAccountParams {
+        account: accounts.reward_token_vault_info.clone(),
+        destination: accounts.lending_market_owner_info.clone(),
+        authority: accounts.reward_authority_info.clone(),
+        authority_signer_seeds: &reward_vault_authority_seeds(
+            accounts.lending_market_info.key,
+            accounts.reserve_info.key,
+            accounts.reward_mint_info.key,
+        ),
+        token_program: accounts.token_program_info.clone(),
+    })?;
+
+    // 4.
 
     Reserve::pack(
         *accounts.reserve,
@@ -73,33 +133,39 @@ impl<'a, 'info> ClosePoolRewardAccounts<'a, 'info> {
         iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
     ) -> Result<ClosePoolRewardAccounts<'a, 'info>, ProgramError> {
         let reserve_info = next_account_info(iter)?;
+        let reward_mint_info = next_account_info(iter)?;
+        let reward_token_destination_info = next_account_info(iter)?;
+        let reward_authority_info = next_account_info(iter)?;
+        let reward_token_vault_info = next_account_info(iter)?;
         let lending_market_info = next_account_info(iter)?;
         let lending_market_owner_info = next_account_info(iter)?;
+        let token_program_info = next_account_info(iter)?;
 
-        if reserve_info.owner != program_id {
-            msg!("Reserve provided is not owned by the lending program");
-            return Err(LendingError::InvalidAccountOwner.into());
+        let (_, reserve) = check_and_unpack_pool_reward_accounts_for_admin_ixs(
+            program_id,
+            reserve_info,
+            reward_mint_info,
+            reward_authority_info,
+            lending_market_info,
+            lending_market_owner_info,
+            token_program_info,
+        )?;
+
+        if reward_token_destination_info.owner != token_program_info.key {
+            msg!("Reward token destination provided must be owned by the token program");
+            return Err(LendingError::InvalidTokenOwner.into());
         }
-        let reserve = Box::new(Reserve::unpack(&reserve_info.data.borrow())?);
-
-        if lending_market_info.owner != program_id {
-            msg!("Lending market provided is not owned by the lending program");
-            return Err(LendingError::InvalidAccountOwner.into());
-        }
-        let lending_market = LendingMarket::unpack(&lending_market_info.data.borrow())?;
-
-        if reserve.lending_market != *lending_market_info.key {
-            msg!("Reserve lending market does not match the lending market provided");
+        let reward_token_destination =
+            unpack_token_account(&reward_token_destination_info.data.borrow())?;
+        if reward_token_destination.mint != *reward_mint_info.key {
+            msg!("Reward token destination mint does not match the reward mint provided");
             return Err(LendingError::InvalidAccountInput.into());
         }
 
-        if lending_market.owner != *lending_market_owner_info.key {
-            msg!("Lending market owner does not match the lending market owner provided");
-            return Err(LendingError::InvalidMarketOwner.into());
-        }
-        if !lending_market_owner_info.is_signer {
-            msg!("Lending market owner provided must be a signer");
-            return Err(LendingError::InvalidSigner.into());
+        let reward_token_vault = unpack_token_account(&reward_token_vault_info.data.borrow())?;
+        if reward_token_vault.mint != *reward_mint_info.key {
+            msg!("Reward token vault mint does not match the reward mint provided");
+            return Err(LendingError::InvalidAccountInput.into());
         }
 
         // check that accounts that should be writable are writable
@@ -108,13 +174,27 @@ impl<'a, 'info> ClosePoolRewardAccounts<'a, 'info> {
             msg!("Reserve provided must be writable");
             return Err(ProgramError::InvalidAccountData);
         }
+        if !reward_token_destination_info.is_writable {
+            msg!("Reward token destination provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reward_token_vault_info.is_writable {
+            msg!("Reward token vault provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
 
         Ok(Self {
             reserve_info,
-            _lending_market_info: lending_market_info,
-            _lending_market_owner_info: lending_market_owner_info,
+            reward_mint_info,
+            reward_token_destination_info,
+            reward_authority_info,
+            reward_token_vault_info,
+            lending_market_info,
+            lending_market_owner_info,
+            token_program_info,
 
             reserve,
+            reward_token_vault,
         })
     }
 }

--- a/token-lending/program/src/processor/liquidity_mining/upgrade_reserve.rs
+++ b/token-lending/program/src/processor/liquidity_mining/upgrade_reserve.rs
@@ -13,6 +13,7 @@ use solana_program::{
 use solend_sdk::state::discriminator::AccountDiscriminator;
 use solend_sdk::state::RESERVE_LEN_V2_0_2;
 use solend_sdk::{error::LendingError, state::Reserve};
+
 struct UpgradeReserveAccounts<'a, 'info> {
     /// Reserve sized as v2.0.2.
     ///
@@ -45,9 +46,7 @@ struct UpgradeReserveAccounts<'a, 'info> {
 pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts = UpgradeReserveAccounts::from_unchecked_iter(program_id, &mut accounts.iter())?;
 
-    //
     // 1.
-    //
 
     let current_rent = accounts.reserve_info.lamports();
     let new_rent = Rent::get()?.minimum_balance(Reserve::LEN);
@@ -70,9 +69,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
         )?;
     }
 
-    //
     // 2.
-    //
 
     // From the [AccountInfo::realloc] docs:
     //
@@ -84,9 +81,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
     let zero_init = false;
     accounts.reserve_info.realloc(Reserve::LEN, zero_init)?;
 
-    //
     // 3.
-    //
 
     // we upgrade discriminator as we've checked that the account is indeed
     // a reserve account in [UpgradeReserveAccounts::from_unchecked_iter]

--- a/token-lending/program/src/processor/liquidity_mining/upgrade_reserve.rs
+++ b/token-lending/program/src/processor/liquidity_mining/upgrade_reserve.rs
@@ -1,0 +1,151 @@
+use solana_program::program_pack::Pack;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program::invoke,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_instruction,
+    sysvar::Sysvar,
+};
+use solend_sdk::state::discriminator::AccountDiscriminator;
+use solend_sdk::state::RESERVE_LEN_V2_0_2;
+use solend_sdk::{error::LendingError, state::Reserve};
+struct UpgradeReserveAccounts<'a, 'info> {
+    /// Reserve sized as v2.0.2.
+    ///
+    /// ✅ belongs to this program
+    /// ✅ is sized [RESERVE_LEN_V2_0_2], ie. for sure [Reserve] account
+    /// ✅ is writable
+    reserve_info: &'a AccountInfo<'info>,
+    /// The pool fella who pays for this.
+    ///
+    /// ✅ is a signer
+    /// ✅ is writable
+    payer: &'a AccountInfo<'info>,
+    /// The system program.
+    ///
+    /// ✅ is the system program
+    system_program: &'a AccountInfo<'info>,
+}
+
+/// Temporary ix to upgrade a reserve to LM feature added in @v2.0.2.
+/// Fails if reserve was not sized as @v2.0.2.
+///
+/// Until this ix is called for a [Reserve] account, all other ixs that try to
+/// unpack the [Reserve] will fail due to size mismatch.
+///
+/// # Effects
+///
+/// 1. Takes payer's lamports and pays for the rent increase.
+/// 2. Reallocates the reserve account to the latest size.
+/// 3. Repacks the reserve account.
+pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let accounts = UpgradeReserveAccounts::from_unchecked_iter(program_id, &mut accounts.iter())?;
+
+    //
+    // 1.
+    //
+
+    let current_rent = accounts.reserve_info.lamports();
+    let new_rent = Rent::get()?.minimum_balance(Reserve::LEN);
+
+    if let Some(extra_rent) = new_rent.checked_sub(current_rent) {
+        // some reserves have more rent than necessary, let's not assume that
+        // the payer always needs to add more rent
+
+        invoke(
+            &system_instruction::transfer(
+                accounts.payer.key,
+                accounts.reserve_info.key,
+                extra_rent,
+            ),
+            &[
+                accounts.payer.clone(),
+                accounts.reserve_info.clone(),
+                accounts.system_program.clone(),
+            ],
+        )?;
+    }
+
+    //
+    // 2.
+    //
+
+    // From the [AccountInfo::realloc] docs:
+    //
+    // > Memory used to grow is already zero-initialized upon program entrypoint
+    // > and re-zeroing it wastes compute units. If within the same call a program
+    // > reallocs from larger to smaller and back to larger again the new space
+    // > could contain stale data. Pass true for zero_init in this case,
+    // > otherwise compute units will be wasted re-zero-initializing.
+    let zero_init = false;
+    accounts.reserve_info.realloc(Reserve::LEN, zero_init)?;
+
+    //
+    // 3.
+    //
+
+    // we upgrade discriminator as we've checked that the account is indeed
+    // a reserve account in [UpgradeReserveAccounts::from_unchecked_iter]
+    let mut data = accounts.reserve_info.data.borrow_mut();
+    data[0] = AccountDiscriminator::Reserve as u8;
+    // Now the reserve can unpack fine and doesn't have to worry about
+    // migrations.
+    // Instead it returns an error on an invalid discriminator.
+    // This way a reserve cannot be mistaken for an obligation.
+    let reserve = Reserve::unpack(&data)?;
+    Reserve::pack(reserve, &mut data)?;
+
+    Ok(())
+}
+
+impl<'a, 'info> UpgradeReserveAccounts<'a, 'info> {
+    fn from_unchecked_iter(
+        program_id: &Pubkey,
+        iter: &mut impl Iterator<Item = &'a AccountInfo<'info>>,
+    ) -> Result<UpgradeReserveAccounts<'a, 'info>, ProgramError> {
+        let reserve_info = next_account_info(iter)?;
+        let payer = next_account_info(iter)?;
+        let system_program = next_account_info(iter)?;
+
+        if !payer.is_signer {
+            msg!("Payer provided must be a signer");
+            return Err(LendingError::InvalidSigner.into());
+        }
+
+        if reserve_info.owner != program_id {
+            msg!("Reserve provided must be owned by the lending program");
+            return Err(LendingError::InvalidAccountOwner.into());
+        }
+
+        if reserve_info.data_len() != RESERVE_LEN_V2_0_2 {
+            msg!("Reserve provided must be sized as v2.0.2");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        if system_program.key != &solana_program::system_program::id() {
+            msg!("System program provided must be the system program");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        // check that accounts that should be writable are writable
+
+        if !payer.is_writable {
+            msg!("Payer provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !reserve_info.is_writable {
+            msg!("Reserve provided must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self {
+            payer,
+            reserve_info,
+            system_program,
+        })
+    }
+}

--- a/token-lending/sdk/src/error.rs
+++ b/token-lending/sdk/src/error.rs
@@ -223,6 +223,9 @@ pub enum LendingError {
     /// Trying to use an account that hasn't been migrated
     #[error("Trying to use an account that hasn't been migrated")]
     AccountNotMigrated,
+    /// There's no pool reward that matches the given parameters
+    #[error("There's no pool reward that matches the given parameters")]
+    NoPoolRewardMatches,
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -568,8 +568,17 @@ pub enum LendingInstruction {
     /// * Can only be called if all users claimed rewards.
     ///
     ///    `[writable]` Reserve account.
+    ///    `[]` Reward mint.
+    ///    `[writable]` Reward token account owned by signer
+    ///    `[]` Derived reserve pool reward authority. Seed:
+    ///         * b"RewardVaultAuthority"
+    ///         * Lending market account pubkey
+    ///         * Reserve account pubkey
+    ///         * Reward mint pubkey
+    ///    `[writable]` Reward vault token account.
     ///    `[]` Lending market account.
     ///    `[signer]` Lending market owner.
+    ///    `[]` Token program.
     ClosePoolReward {
         /// Whether this reward applies to deposits or borrows
         position_kind: PositionKind,

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -609,8 +609,9 @@ pub enum LendingInstruction {
     /// * User can claim rewards from their obligation.
     ///
     ///   `[writable]` Obligation account.
-    ///   `[writable]` User reward receiving token account.
+    ///   `[writable]` Obligation owner reward receiving token account.
     ///   `[writable]` Reserve account.
+    ///   `[]` Reward mint.
     ///   `[]` Derived reserve pool reward authority. Seed:
     ///        * b"RewardVaultAuthority"
     ///        * Lending market account pubkey

--- a/token-lending/sdk/src/instruction.rs
+++ b/token-lending/sdk/src/instruction.rs
@@ -568,23 +568,13 @@ pub enum LendingInstruction {
     /// * Can only be called if all users claimed rewards.
     ///
     ///    `[writable]` Reserve account.
-    ///    `[]` Reward mint.
-    ///    `[writable]` Reward token account owned by signer
-    ///    `[]` Derived reserve pool reward authority. Seed:
-    ///         * b"RewardVaultAuthority"
-    ///         * Lending market account pubkey
-    ///         * Reserve account pubkey
-    ///         * Reward mint pubkey
-    ///    `[writable]` Reward vault token account.
     ///    `[]` Lending market account.
     ///    `[signer]` Lending market owner.
-    ///    `[]` Rent sysvar.
-    ///    `[]` Token program.
     ClosePoolReward {
         /// Whether this reward applies to deposits or borrows
         position_kind: PositionKind,
         /// Identifies a reward within a reserve's deposits/borrows rewards.
-        pool_reward_index: u64,
+        pool_reward_index: usize,
     },
 
     // 27
@@ -605,14 +595,31 @@ pub enum LendingInstruction {
     ///    `[writable]` Reward vault token account.
     ///    `[]` Lending market account.
     ///    `[signer]` Lending market owner.
-    ///    `[]` Rent sysvar.
     ///    `[]` Token program.
     CancelPoolReward {
         /// Whether this reward applies to deposits or borrows
         position_kind: PositionKind,
         /// Identifies a reward within a reserve's deposits/borrows rewards.
-        pool_reward_index: u64,
+        pool_reward_index: usize,
     },
+
+    /// 28
+    /// ClaimReward
+    ///
+    /// * User can claim rewards from their obligation.
+    ///
+    ///   `[writable]` Obligation account.
+    ///   `[writable]` User reward receiving token account.
+    ///   `[writable]` Reserve account.
+    ///   `[]` Derived reserve pool reward authority. Seed:
+    ///        * b"RewardVaultAuthority"
+    ///        * Lending market account pubkey
+    ///        * Reserve account pubkey
+    ///        * Reward mint pubkey
+    ///   `[writable]` Reward vault token account.
+    ///   `[]` Lending market account.
+    ///   `[]` Token program.
+    ClaimReward,
 
     // 255
     /// UpgradeReserveToV2_1_0
@@ -900,7 +907,7 @@ impl LendingInstruction {
                 let (pool_reward_index, _rest) = Self::unpack_u64(rest)?;
                 Self::ClosePoolReward {
                     position_kind,
-                    pool_reward_index,
+                    pool_reward_index: pool_reward_index as _,
                 }
             }
             27 => {
@@ -908,9 +915,10 @@ impl LendingInstruction {
                 let (pool_reward_index, _rest) = Self::unpack_u64(rest)?;
                 Self::CancelPoolReward {
                     position_kind,
-                    pool_reward_index,
+                    pool_reward_index: pool_reward_index as _,
                 }
             }
+            28 => Self::ClaimReward,
             255 => Self::UpgradeReserveToV2_1_0,
             _ => {
                 msg!("Instruction cannot be unpacked");
@@ -1247,6 +1255,9 @@ impl LendingInstruction {
                 buf.push(27);
                 buf.extend_from_slice(&(position_kind as u8).to_le_bytes());
                 buf.extend_from_slice(&pool_reward_index.to_le_bytes());
+            }
+            Self::ClaimReward => {
+                buf.push(28);
             }
             Self::UpgradeReserveToV2_1_0 => {
                 buf.push(255);

--- a/token-lending/sdk/src/state/lending_market.rs
+++ b/token-lending/sdk/src/state/lending_market.rs
@@ -180,6 +180,7 @@ impl Pack for LendingMarket {
                 msg!("Lending market discriminator does not match");
                 return Err(LendingError::InvalidAccountDiscriminator.into());
             }
+            #[allow(clippy::assertions_on_constants)]
             Err(LendingError::AccountNotMigrated) => {
                 // We're migrating the account from v2.0.2 to v2.1.0.
                 // The reason this is safe to do is conveyed in these asserts:

--- a/token-lending/sdk/src/state/liquidity_mining.rs
+++ b/token-lending/sdk/src/state/liquidity_mining.rs
@@ -175,22 +175,6 @@ pub struct UserReward {
 }
 
 impl PoolRewardManager {
-    /// Returns all rewards that use the given vault.
-    pub fn find_rewards_with_vault(
-        &self,
-        vault: Pubkey,
-    ) -> impl Iterator<Item = (usize, &Box<PoolReward>)> {
-        self.pool_rewards
-            .iter()
-            .enumerate()
-            .filter_map(move |(index, slot)| match slot {
-                PoolRewardSlot::Occupied(pool_reward) if pool_reward.vault == vault => {
-                    Some((index, pool_reward))
-                }
-                _ => None,
-            })
-    }
-
     /// Sets the duration of the pool reward to now.
     /// Returns the amount of unallocated rewards and the vault they are in.
     pub fn cancel_pool_reward(
@@ -226,7 +210,8 @@ impl PoolRewardManager {
     }
 
     /// Closes a pool reward if it has been cancelled before.
-    pub fn close_pool_reward(&mut self, pool_reward_index: usize) -> Result<(), ProgramError> {
+    /// Returns the vault the rewards are in.
+    pub fn close_pool_reward(&mut self, pool_reward_index: usize) -> Result<Pubkey, ProgramError> {
         let Some(PoolRewardSlot::Occupied(pool_reward)) =
             self.pool_rewards.get_mut(pool_reward_index)
         else {
@@ -239,12 +224,14 @@ impl PoolRewardManager {
             return Err(LendingError::InvalidAccountInput.into());
         }
 
+        let vault = pool_reward.vault;
+
         self.pool_rewards[pool_reward_index] = PoolRewardSlot::Vacant {
             last_pool_reward_id: pool_reward.id,
             has_been_vacated_in_this_tx: true,
         };
 
-        Ok(())
+        Ok(vault)
     }
 
     /// Should be updated before any interaction with rewards.
@@ -310,48 +297,49 @@ pub enum CreatingNewUserRewardManager {
 impl UserRewardManager {
     /// Claims all rewards that the user has earned.
     /// Returns how many tokens should be transferred to the user.
+    ///
+    /// # Note
+    /// Errors if there is no pool reward with this vault.
     pub fn claim_rewards(
         &mut self,
         pool_reward_manager: &mut PoolRewardManager,
         vault: Pubkey,
         clock: &Clock,
     ) -> Result<u64, ProgramError> {
-        let mut total_reward_amount = 0;
-        let mut should_update_managers = false;
-        for user_reward in &mut self.rewards {
-            let Some(PoolRewardSlot::Occupied(pool_reward)) = pool_reward_manager
-                .pool_rewards
-                .get(user_reward.pool_reward_index)
-            else {
-                unreachable!("User reward points to a non-existent pool reward");
-            };
+        let (pool_reward_index, pool_reward) = pool_reward_manager
+            .pool_rewards
+            .iter()
+            .enumerate()
+            .find_map(move |(index, slot)| match slot {
+                PoolRewardSlot::Occupied(pool_reward) if pool_reward.vault == vault => {
+                    Some((index, pool_reward))
+                }
+                _ => None,
+            })
+            .ok_or(LendingError::NoPoolRewardMatches)?;
 
-            if pool_reward.vault != vault {
-                // not the pool reward we are looking for
-                continue;
-            }
+        let Some(user_reward) = self.rewards.iter_mut().find(|user_reward| {
+            user_reward.pool_reward_index == pool_reward_index
+                && user_reward.pool_reward_id == pool_reward.id
+        }) else {
+            // User is not tracking this reward, nothing to claim.
+            // Let's be graceful and make this a no-op.
+            // Prevents failures when multiple parties crank rewards.
+            return Ok(0);
+        };
 
-            if user_reward.pool_reward_id != pool_reward.id {
-                unreachable!("User reward points to an outdated pool reward");
-            }
+        let to_claim = user_reward.withdraw_earned_rewards()?;
 
-            total_reward_amount += user_reward.withdraw_earned_rewards()?;
-
-            if pool_reward.has_ended(clock) {
-                // if pool reward has ended then it will be removed from the user
-                // reward manager in the next update call
-                should_update_managers = true;
-            }
-        }
-
-        if should_update_managers {
-            // Only do this is we know something will change.
+        if pool_reward.has_ended(clock) {
+            // If pool reward has ended then it will be removed from the user
+            // reward manager in the next update call.
+            //
             // We could also complicate matters by doing updates in place when
             // needed to save on CU if necessary.
             self.update(pool_reward_manager, clock, CreatingNewUserRewardManager::No)?;
         }
 
-        Ok(total_reward_amount)
+        Ok(to_claim)
     }
 
     /// Should be updated before any interaction with rewards.

--- a/token-lending/sdk/src/state/liquidity_mining.rs
+++ b/token-lending/sdk/src/state/liquidity_mining.rs
@@ -1,17 +1,18 @@
+use super::pack_decimal;
 use crate::{
     error::LendingError,
     math::{Decimal, TryAdd, TryDiv, TryMul, TrySub},
     state::unpack_decimal,
 };
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_program::msg;
 use solana_program::program_pack::{Pack, Sealed};
 use solana_program::{
     clock::Clock,
     program_error::ProgramError,
     pubkey::{Pubkey, PUBKEY_BYTES},
 };
-
-use super::pack_decimal;
+use std::convert::TryFrom;
 
 /// Determines the size of [PoolRewardManager]
 pub const MAX_REWARDS: usize = 50;
@@ -74,6 +75,7 @@ pub enum PoolRewardSlot {
 /// Tracks rewards in a specific mint over some period of time.
 ///
 /// # Reward cancellation
+///
 /// In Suilend we also store the amount of rewards that have been made available
 /// to users already.
 /// We keep adding `(total_rewards * time_passed) / (total_time)` every
@@ -92,6 +94,10 @@ pub struct PoolReward {
     /// Monotonically increasing time taken from clock sysvar.
     pub start_time_secs: u64,
     /// For how long (since start time) will this reward be releasing tokens.
+    ///
+    /// # Reward cancellation
+    ///
+    /// Is cut short if the reward is cancelled.
     pub duration_secs: u32,
     /// Total token amount to distribute.
     /// The token account that holds the rewards holds at least this much in
@@ -169,6 +175,77 @@ pub struct UserReward {
 }
 
 impl PoolRewardManager {
+    /// Returns all rewards that use the given vault.
+    pub fn find_rewards_with_vault(
+        &self,
+        vault: Pubkey,
+    ) -> impl Iterator<Item = (usize, &Box<PoolReward>)> {
+        self.pool_rewards
+            .iter()
+            .enumerate()
+            .filter_map(move |(index, slot)| match slot {
+                PoolRewardSlot::Occupied(pool_reward) if pool_reward.vault == vault => {
+                    Some((index, pool_reward))
+                }
+                _ => None,
+            })
+    }
+
+    /// Sets the duration of the pool reward to now.
+    /// Returns the amount of unallocated rewards and the vault they are in.
+    pub fn cancel_pool_reward(
+        &mut self,
+        pool_reward_index: usize,
+        clock: &Clock,
+    ) -> Result<(Pubkey, u64), ProgramError> {
+        self.update(clock)?;
+
+        let Some(PoolRewardSlot::Occupied(pool_reward)) =
+            self.pool_rewards.get_mut(pool_reward_index)
+        else {
+            msg!("Cannot cancel a non-existent pool reward");
+            return Err(ProgramError::InvalidArgument);
+        };
+
+        if pool_reward.has_ended(clock) {
+            msg!("Cannot cancel a pool reward that has already ended");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        let since_start_secs = clock.unix_timestamp as u64 - pool_reward.start_time_secs;
+        let unlocked_rewards = Decimal::from(pool_reward.total_rewards)
+            .try_mul(Decimal::from(since_start_secs))?
+            .try_div(Decimal::from(pool_reward.duration_secs as u64))?
+            .try_floor_u64()?;
+
+        pool_reward.duration_secs =
+            u32::try_from(since_start_secs).expect("New duration to be strictly shorter");
+
+        Ok((pool_reward.vault, unlocked_rewards))
+    }
+
+    /// Closes a pool reward if it has been cancelled before.
+    pub fn close_pool_reward(&mut self, pool_reward_index: usize) -> Result<(), ProgramError> {
+        let Some(PoolRewardSlot::Occupied(pool_reward)) =
+            self.pool_rewards.get_mut(pool_reward_index)
+        else {
+            msg!("Cannot close a non-existent pool reward");
+            return Err(ProgramError::InvalidArgument);
+        };
+
+        if pool_reward.num_user_reward_managers > 0 {
+            msg!("Cannot close a pool reward with active user reward managers");
+            return Err(LendingError::InvalidAccountInput.into());
+        }
+
+        self.pool_rewards[pool_reward_index] = PoolRewardSlot::Vacant {
+            last_pool_reward_id: pool_reward.id,
+            has_been_vacated_in_this_tx: true,
+        };
+
+        Ok(())
+    }
+
     /// Should be updated before any interaction with rewards.
     fn update(&mut self, clock: &Clock) -> Result<(), ProgramError> {
         let curr_unix_timestamp_secs = clock.unix_timestamp as u64;
@@ -219,19 +296,69 @@ impl PoolRewardManager {
     }
 }
 
-enum CreatingNewUserRewardManager {
+/// When creating a new [UserRewardManager] we need to know whether we should
+/// populate it with rewards or not.
+pub enum CreatingNewUserRewardManager {
     /// If we are creating a [UserRewardManager] then we want to populate it.
     Yes,
+    /// If we are updating an existing [UserRewardManager] then we don't want
+    /// to populate it.
     No,
 }
 
 impl UserRewardManager {
+    /// Claims all rewards that the user has earned.
+    /// Returns how many tokens should be transferred to the user.
+    pub fn claim_rewards(
+        &mut self,
+        pool_reward_manager: &mut PoolRewardManager,
+        vault: Pubkey,
+        clock: &Clock,
+    ) -> Result<u64, ProgramError> {
+        let mut total_reward_amount = 0;
+        let mut should_update_managers = false;
+        for user_reward in &mut self.rewards {
+            let Some(PoolRewardSlot::Occupied(pool_reward)) = pool_reward_manager
+                .pool_rewards
+                .get(user_reward.pool_reward_index)
+            else {
+                unreachable!("User reward points to a non-existent pool reward");
+            };
+
+            if pool_reward.vault != vault {
+                // not the pool reward we are looking for
+                continue;
+            }
+
+            if user_reward.pool_reward_id != pool_reward.id {
+                unreachable!("User reward points to an outdated pool reward");
+            }
+
+            total_reward_amount += user_reward.withdraw_earned_rewards()?;
+
+            if pool_reward.has_ended(clock) {
+                // if pool reward has ended then it will be removed from the user
+                // reward manager in the next update call
+                should_update_managers = true;
+            }
+        }
+
+        if should_update_managers {
+            // Only do this is we know something will change.
+            // We could also complicate matters by doing updates in place when
+            // needed to save on CU if necessary.
+            self.update(pool_reward_manager, clock, CreatingNewUserRewardManager::No)?;
+        }
+
+        Ok(total_reward_amount)
+    }
+
     /// Should be updated before any interaction with rewards.
     ///
     /// # Assumption
     /// Invoker has checked that this [PoolRewardManager] matches the
     /// [UserRewardManager].
-    fn update(
+    pub fn update(
         &mut self,
         pool_reward_manager: &mut PoolRewardManager,
         clock: &Clock,
@@ -257,23 +384,23 @@ impl UserRewardManager {
                 continue;
             };
 
-            let end_time_secs = pool_reward.start_time_secs + pool_reward.duration_secs as u64;
-            let has_ended = self.last_update_time_secs > end_time_secs;
-
             let maybe_user_reward = self
                 .rewards
                 .iter_mut()
                 .enumerate()
                 .find(|(_, r)| r.pool_reward_index == pool_reward_index);
 
+            let end_time_secs = pool_reward.start_time_secs + pool_reward.duration_secs as u64;
+            let has_ended = self.last_update_time_secs > end_time_secs;
+
             match maybe_user_reward {
                 Some((user_reward_index, user_reward))
-                    if has_ended && user_reward.earned_rewards == Decimal::zero() =>
+                    if has_ended && user_reward.earned_rewards.try_floor_u64()? == 0 =>
                 {
                     // Reward period ended and there's nothing to crank.
                     // We can clean up this user reward.
                     // We're fine with swap remove bcs `user_reward_index` is meaningless.
-                    // SAFETY: We got the index from enumeration, so must exist/
+                    // SAFETY: We got the index from enumeration, so must exist.
                     self.rewards.swap_remove(user_reward_index);
                     pool_reward.num_user_reward_managers -= 1;
                 }
@@ -338,6 +465,12 @@ impl PoolReward {
     /// - `num_user_reward_managers``
     /// - `cumulative_rewards_per_share``
     const TAIL_LEN: usize = 8 + 4 + 8 + 8 + 16;
+
+    /// Returns whether the reward has ended.
+    pub fn has_ended(&self, clock: &Clock) -> bool {
+        let end_time_secs = self.start_time_secs + self.duration_secs as u64;
+        clock.unix_timestamp as u64 > end_time_secs
+    }
 }
 
 impl PoolRewardId {
@@ -523,6 +656,20 @@ impl UserReward {
     /// - packed [Decimal]
     /// - packed [Decimal]
     pub const LEN: usize = 1 + PoolRewardId::LEN + 16 + 16;
+
+    /// Removes all earned rewards from [Self] and returns them.
+    ///
+    /// # Note
+    /// Decimals are truncated to u64, dust is kept.
+    fn withdraw_earned_rewards(&mut self) -> Result<u64, ProgramError> {
+        let reward_amount = self.earned_rewards.try_floor_u64()?;
+
+        if reward_amount > 0 {
+            self.earned_rewards = self.earned_rewards.try_sub(reward_amount.into())?;
+        }
+
+        Ok(reward_amount)
+    }
 }
 
 impl UserRewardManager {

--- a/token-lending/sdk/src/state/liquidity_mining.rs
+++ b/token-lending/sdk/src/state/liquidity_mining.rs
@@ -217,11 +217,12 @@ impl PoolRewardManager {
             .try_mul(Decimal::from(since_start_secs))?
             .try_div(Decimal::from(pool_reward.duration_secs as u64))?
             .try_floor_u64()?;
+        let remaining_rewards = pool_reward.total_rewards - unlocked_rewards;
 
         pool_reward.duration_secs =
             u32::try_from(since_start_secs).expect("New duration to be strictly shorter");
 
-        Ok((pool_reward.vault, unlocked_rewards))
+        Ok((pool_reward.vault, remaining_rewards))
     }
 
     /// Closes a pool reward if it has been cancelled before.

--- a/token-lending/sdk/src/state/liquidity_mining.rs
+++ b/token-lending/sdk/src/state/liquidity_mining.rs
@@ -585,6 +585,7 @@ impl Pack for PoolRewardManager {
             let offset = 8 + 8 + index * PoolReward::LEN;
             let raw_pool_reward_head = array_ref![input, offset, PoolReward::HEAD_LEN];
 
+            #[allow(clippy::ptr_offset_with_cast)]
             let (src_id, src_vault) =
                 array_refs![raw_pool_reward_head, PoolRewardId::LEN, PUBKEY_BYTES];
 
@@ -747,8 +748,10 @@ impl UserRewardManager {
     }
 
     pub(crate) fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
+        #[allow(clippy::ptr_offset_with_cast)]
         let raw_user_reward_manager_head = array_ref![input, 0, UserRewardManager::HEAD_LEN];
 
+        #[allow(clippy::ptr_offset_with_cast)]
         let (src_reserve, src_share, src_last_update_time_secs, src_user_rewards_len) = array_refs![
             raw_user_reward_manager_head,
             PUBKEY_BYTES,
@@ -767,6 +770,7 @@ impl UserRewardManager {
             let offset = Self::HEAD_LEN + index * UserReward::LEN;
             let raw_user_reward = array_ref![input, offset, UserReward::LEN];
 
+            #[allow(clippy::ptr_offset_with_cast)]
             let (
                 src_pool_reward_index,
                 src_pool_reward_id,

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -313,6 +313,38 @@ impl Obligation {
             .iter()
             .position(|liquidity| liquidity.borrow_reserve == borrow_reserve)
     }
+
+    /// Find whether the reserve is a deposit or borrow
+    pub fn find_position_kind(&self, reserve: Pubkey) -> Result<PositionKind, ProgramError> {
+        if self
+            .deposits
+            .iter()
+            .any(|collateral| collateral.deposit_reserve == reserve)
+        {
+            return Ok(PositionKind::Deposit);
+        }
+
+        if self
+            .borrows
+            .iter()
+            .any(|liquidity| liquidity.borrow_reserve == reserve)
+        {
+            return Ok(PositionKind::Borrow);
+        }
+
+        msg!("Reserve not found in obligation");
+        Err(LendingError::InvalidAccountInput.into())
+    }
+
+    /// Returns [UserRewardManager] for the given reserve
+    pub fn find_user_reward_manager_mut(
+        &mut self,
+        reserve: Pubkey,
+    ) -> Option<&mut UserRewardManager> {
+        self.user_reward_managers
+            .iter_mut()
+            .find(|user_reward_manager| user_reward_manager.reserve == reserve)
+    }
 }
 
 /// Initialize an obligation

--- a/token-lending/sdk/src/state/obligation.rs
+++ b/token-lending/sdk/src/state/obligation.rs
@@ -501,7 +501,7 @@ impl Obligation {
     /// Unpacks from slice but returns an error if the account is already
     /// initialized.
     pub fn unpack_uninitialized(input: &[u8]) -> Result<Self, ProgramError> {
-        let account = Self::unpack_unchecked(&input)?;
+        let account = Self::unpack_unchecked(input)?;
         if account.is_initialized() {
             Err(LendingError::AlreadyInitialized.into())
         } else {

--- a/token-lending/sdk/src/state/reserve.rs
+++ b/token-lending/sdk/src/state/reserve.rs
@@ -1698,6 +1698,7 @@ impl Pack for Reserve {
         };
 
         let input_v2_1_0 = array_ref![input, RESERVE_LEN_V2_0_2, PoolRewardManager::LEN * 2];
+        #[allow(clippy::ptr_offset_with_cast)]
         let (input_for_borrows_pool_reward_manager, input_for_deposits_pool_reward_manager) =
             array_refs![input_v2_1_0, PoolRewardManager::LEN, PoolRewardManager::LEN];
 


### PR DESCRIPTION
- fill in logic for all ixs but adding rewards
- permission-less ix to claim rewards
- split LM ix into separate modules
- address clippy suggestions and fix everything so that CI is green

---

- [x] Revert back close ix to also close token account
- [x] One vault is only valid for one reward