### PR TITLE
Security Fix: Extra oracle skips staleness/confidence checks

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -577,10 +577,16 @@ fn _refresh_reserve<'a>(
                     return Err(LendingError::InvalidAccountInput.into());
                 }
 
-                Some(get_single_price_unchecked(
-                    extra_oracle_account_info,
-                    clock,
-                )?)
+                // SECURITY FIX: Use checked price to enforce staleness and
+                // confidence validation on the extra oracle, preventing
+                // price manipulation attacks.
+                {
+                    let (price, _ema_price) = oracles::get_single_price(
+                        extra_oracle_account_info,
+                        clock,
+                    )?;
+                    Some(price)
+                }
             }
             None => {
                 msg!("Reserve extra oracle account info missing");


### PR DESCRIPTION
## Security Finding

### [HIGH] Extra Oracle Uses get_single_price_unchecked
**File:** `token-lending/program/src/processor.rs:580`

**Issue:**
The extra oracle price is fetched using `get_single_price_unchecked()` which bypasses staleness and confidence interval validation (unlike the primary oracle which uses `get_single_price()`).

**Impact:**
An attacker can exploit this by:
1. Waiting for the extra oracle to become stale (price not updated)
2. The stale price may significantly differ from the actual market price
3. This creates an arbitrage opportunity in borrow/liquidation calculations
4. The attacker can borrow more than they should, or trigger unfair liquidations

**Fix:** Changed to `get_single_price()` which enforces proper oracle validation including staleness checks and confidence interval bounds.

---
*Found during a Solana security audit*